### PR TITLE
Improve code structure and fix php-cs-fixer

### DIFF
--- a/demoextendsymfonyform2/demoextendsymfonyform2.php
+++ b/demoextendsymfonyform2/demoextendsymfonyform2.php
@@ -101,7 +101,6 @@ class DemoExtendSymfonyForm2 extends Module
                     ],
                 ]);
         }
-
     }
 
     /**
@@ -137,5 +136,4 @@ class DemoExtendSymfonyForm2 extends Module
             $supplierExtraImageUploader->upload($params['id'], $uploadedFile);
         }
     }
-
 }

--- a/demoextendsymfonyform2/src/Entity/SupplierExtraImage.php
+++ b/demoextendsymfonyform2/src/Entity/SupplierExtraImage.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 namespace PrestaShop\Module\DemoExtendSymfonyForm\Entity;
+
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -88,5 +89,4 @@ class SupplierExtraImage
     {
         $this->imageName = $imageName;
     }
-
 }

--- a/demoextendsymfonyform2/src/Install/Installer.php
+++ b/demoextendsymfonyform2/src/Install/Installer.php
@@ -69,7 +69,7 @@ class Installer
      */
     private function uninstallDatabase(): bool
     {
-        return $this->executeQueries(SqlQueries::uninstallQueries);
+        return $this->executeQueries(SqlQueries::uninstallQueries());
     }
 
     /**

--- a/demoextendsymfonyform2/src/Install/Installer.php
+++ b/demoextendsymfonyform2/src/Install/Installer.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\DemoExtendSymfonyForm\Install;
 
-
 use Db;
 use Module;
+use PrestaShop\Module\DemoExtendSymfonyForm\Sql\SqlQueries;
 
 /**
  * Class Installer
@@ -59,16 +59,7 @@ class Installer
      */
     private function installDatabase(): bool
     {
-        $queries = [
-            'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'supplier_extra_image` (
-              `id_extra_image` int(11) NOT NULL AUTO_INCREMENT,
-              `id_supplier` int(11) NOT NULL,
-              `image_name` varchar(64) NOT NULL,
-              PRIMARY KEY (`id_extra_image`)
-            ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8;',
-        ];
-
-        return $this->executeQueries($queries);
+        return $this->executeQueries(SqlQueries::installQueries());
     }
 
     /**
@@ -78,11 +69,7 @@ class Installer
      */
     private function uninstallDatabase(): bool
     {
-        $queries = [
-            'DROP TABLE IF EXISTS `'._DB_PREFIX_.'supplier_extra_image`',
-        ];
-
-        return $this->executeQueries($queries);
+        return $this->executeQueries(SqlQueries::uninstallQueries);
     }
 
     /**

--- a/demoextendsymfonyform2/src/Sql/SqlQueries.php
+++ b/demoextendsymfonyform2/src/Sql/SqlQueries.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\DemoExtendSymfonyForm\Sql;
+
+/**
+ * Class SqlQueries
+ * @package PrestaShop\Module\DemoExtendSymfonyForm\Sql
+ */
+class SqlQueries
+{
+    /**
+     * Install database queries.
+     *
+     * @return array
+     */
+    public static function installQueries(): array
+    {
+        $queries = [
+            'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'supplier_extra_image` (
+              `id_extra_image` int(11) NOT NULL AUTO_INCREMENT,
+              `id_supplier` int(11) NOT NULL,
+              `image_name` varchar(64) NOT NULL,
+              PRIMARY KEY (`id_extra_image`)
+            ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8;',
+        ];
+
+        return $queries;
+    }
+
+    /**
+     * Uninstall database queries.
+     *
+     * @return bool
+     */
+    public static function uninstallQueries(): array
+    {
+        $queries = [
+            'DROP TABLE IF EXISTS `'._DB_PREFIX_.'supplier_extra_image`',
+        ];
+
+        return $queries;
+    }
+}

--- a/demoextendsymfonyform2/src/Sql/SqlQueries.php
+++ b/demoextendsymfonyform2/src/Sql/SqlQueries.php
@@ -42,10 +42,8 @@ class SqlQueries
      */
     public static function uninstallQueries(): array
     {
-        $queries = [
+        return [
             'DROP TABLE IF EXISTS `'._DB_PREFIX_.'supplier_extra_image`',
         ];
-
-        return $queries;
     }
 }

--- a/demoextendsymfonyform2/src/Sql/SqlQueries.php
+++ b/demoextendsymfonyform2/src/Sql/SqlQueries.php
@@ -25,7 +25,7 @@ class SqlQueries
      */
     public static function installQueries(): array
     {
-        $queries = [
+        return [
             'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'supplier_extra_image` (
               `id_extra_image` int(11) NOT NULL AUTO_INCREMENT,
               `id_supplier` int(11) NOT NULL,
@@ -33,8 +33,6 @@ class SqlQueries
               PRIMARY KEY (`id_extra_image`)
             ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8;',
         ];
-
-        return $queries;
     }
 
     /**

--- a/demoextendsymfonyform2/src/Uploader/SupplierExtraImageUploader.php
+++ b/demoextendsymfonyform2/src/Uploader/SupplierExtraImageUploader.php
@@ -52,8 +52,6 @@ class SupplierExtraImageUploader implements ImageUploaderInterface
         $destination = _PS_SUPP_IMG_DIR_ . $originalImageName;
         $this->uploadFromTemp($tempImageName, $destination);
         $this->supplierExtraImageRepository->upsertSupplierImageName($supplierId, $originalImageName);
-
-
     }
 
     /**
@@ -134,5 +132,4 @@ class SupplierExtraImageUploader implements ImageUploaderInterface
             throw new UploadedImageConstraintException(sprintf('Image format "%s", not recognized, allowed formats are: .gif, .jpg, .png', $image->getClientOriginalExtension()), UploadedImageConstraintException::UNRECOGNIZED_FORMAT);
         }
     }
-
 }


### PR DESCRIPTION
I don't think we should write sql requests directly to the Installer class. 
If it suits you I can do the same with Hooks! 
- It is much easier to find if we want to modify our sql requests for example or hooks ... 
- besides drawback, if the requests and the list of hooks are too long we risk saturating the Installer class