### PR TITLE
[Blocked by Core#19995] Added formatted textaAreaType to module

### DIFF
--- a/demosymfonyform/src/Form/DemoConfigurationDataConfiguration.php
+++ b/demosymfonyform/src/Form/DemoConfigurationDataConfiguration.php
@@ -81,7 +81,7 @@ final class DemoConfigurationDataConfiguration implements DataConfigurationInter
     {
         $this->configuration->set(self::TRANSLATABLE_SIMPLE, json_encode($configuration['translatable_type']));
         $this->configuration->set(self::TRANSLATABLE_TEXT_AREA, json_encode($configuration['translatable_text_area_type']));
-        $this->configuration->set(self::TRANSLATABLE_FORMATTED_TEXT_AREA, json_encode($configuration['translatable_formatted_text_area_type'], JSON_UNESCAPED_SLASHES), ['html' => true]);
+        $this->configuration->set(self::TRANSLATABLE_FORMATTED_TEXT_AREA, json_encode($configuration['translatable_formatted_text_area_type'], JSON_UNESCAPED_SLASHES), null, ['html' => true]);
 
         return [];
     }

--- a/demosymfonyform/src/Form/DemoConfigurationType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationType.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\Module\DemoSymfonyForm\Form;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -73,6 +74,20 @@ class DemoConfigurationType extends TranslatorAwareType
                         ],
                     ],
                 ]
-            );
+            )
+            ->add('translatable_formatted_text_area_type', TranslatableType::class, [
+                'label' => $this->trans('Translatable formatted text area type', 'Modules.DemoSymfonyForm.Admin'),
+                'help' => $this->trans('Throws error if length is > 10', 'Modules.DemoSymfonyForm.Admin'),
+                'type' => FormattedTextareaType::class,
+                'locales' => $this->locales,
+                'required' => false,
+                'options' => [
+                    'constraints' => [
+                        new Length([
+                            'max' => 30,
+                        ]),
+                    ],
+                ],
+            ]);
     }
 }

--- a/demosymfonyform/src/Form/DemoConfigurationType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationType.php
@@ -79,7 +79,6 @@ class DemoConfigurationType extends TranslatorAwareType
                 'label' => $this->trans('Translatable formatted text area type', 'Modules.DemoSymfonyForm.Admin'),
                 'help' => $this->trans('Throws error if length is > 10', 'Modules.DemoSymfonyForm.Admin'),
                 'type' => FormattedTextareaType::class,
-                'locales' => $this->locales,
                 'required' => false,
                 'options' => [
                     'constraints' => [

--- a/demosymfonyform/src/Form/DemoConfigurationType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationType.php
@@ -77,7 +77,7 @@ class DemoConfigurationType extends TranslatorAwareType
             )
             ->add('translatable_formatted_text_area_type', TranslatableType::class, [
                 'label' => $this->trans('Translatable formatted text area type', 'Modules.DemoSymfonyForm.Admin'),
-                'help' => $this->trans('Throws error if length is > 10', 'Modules.DemoSymfonyForm.Admin'),
+                'help' => $this->trans('Throws error if length is > 30', 'Modules.DemoSymfonyForm.Admin'),
                 'type' => FormattedTextareaType::class,
                 'required' => false,
                 'options' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add formatted text area to example form, to make it available for testing.
| Type?         |  improvement
| BC breaks?    | no
| Deprecations? | no
| How to test?  | This PR will only work correctly with https://github.com/PrestaShop/PrestaShop/pull/19995, then form added by module Demo Symfony Form Configuration should have fully working TranslatableTextAreaType.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
