### PR TITLE
Adds demo module for grid extension demonstrations

### DIFF
--- a/demoextendgrid/.gitignore
+++ b/demoextendgrid/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+.idea
+js/node_modules

--- a/demoextendgrid/README.md
+++ b/demoextendgrid/README.md
@@ -1,0 +1,26 @@
+# Demonstration of how to extend grids
+
+## About
+
+This module demonstrates:
+ * how to insert add additional action to existing grid
+
+ ### Supported PrestaShop versions
+
+ This module is compatible with and 1.7.7.0 and above versions.
+ 
+ ### Requirements
+ 
+  1. Composer, see [Composer](https://getcomposer.org/) to learn more
+ 
+ ### How to install
+ 
+  1. Download or clone module into `modules` directory of your PrestaShop installation
+  2. Rename the directory to make sure that module directory is named `demoextendgrid`*
+  3. `cd` into module's directory and run following commands:
+      - `composer install` - to download dependencies into vendor folder
+  4. Install module from Back Office
+ 
+ *Because the name of the directory and the name of the main module file must match.
+ 
+

--- a/demoextendgrid/composer.json
+++ b/demoextendgrid/composer.json
@@ -1,0 +1,21 @@
+{
+  "name": "prestashop/demoextendgrid",
+  "authors": [
+    {
+      "name": "Julius Zukauskas",
+      "email": "julius.zukauskas@invertus.eu"
+    },
+    {
+      "name": "PrestaShop Core team"
+    }
+  ],
+  "autoload": {
+    "psr-4": {
+      "PrestaShop\\Module\\DemoExtendGrid\\": "src/"
+    },
+    "config": {
+      "prepend-autoloader": false
+    },
+    "type": "prestashop-module"
+  }
+}

--- a/demoextendgrid/config/routes.yml
+++ b/demoextendgrid/config/routes.yml
@@ -1,0 +1,7 @@
+admin_suppliers_delete_image:
+  path: demoextendsymfonyform/{supplierId}/delete-image
+  methods: [POST]
+  defaults:
+    _controller: PrestaShop\Module\DemoExtendSymfonyForm\Controller\DemoSupplierController::deleteExtraImageAction
+  requirements:
+    categoryId: \d+

--- a/demoextendgrid/config/routes.yml
+++ b/demoextendgrid/config/routes.yml
@@ -1,7 +1,7 @@
-admin_suppliers_delete_image:
-  path: demoextendsymfonyform/{supplierId}/delete-image
+demo_admin_orders_mark_order:
+  path: demoextendgrid/{orderId}/mark-order
   methods: [POST]
   defaults:
-    _controller: PrestaShop\Module\DemoExtendSymfonyForm\Controller\DemoSupplierController::deleteExtraImageAction
+    _controller: PrestaShop\Module\DemoExtendGrid\Controller\DemoOrderController::markOrder
   requirements:
-    categoryId: \d+
+      orderId: \d+

--- a/demoextendgrid/config/services.yml
+++ b/demoextendgrid/config/services.yml
@@ -1,0 +1,13 @@
+services:
+
+  prestashop.module.demoextendsymfonyform.uploader.supplier_extra_image_uploader:
+    class: PrestaShop\Module\DemoExtendSymfonyForm\Uploader\SupplierExtraImageUploader
+    arguments:
+      - '@prestashop.module.demoextendsymfonyform.repository.supplier_extra_image_repository'
+
+  prestashop.module.demoextendsymfonyform.repository.supplier_extra_image_repository:
+    class: PrestaShop\Module\DemoExtendSymfonyForm\Repository\SupplierExtraImageRepository
+    public: true
+    factory: ['@doctrine.orm.entity_manager', getRepository]
+    arguments:
+      - PrestaShop\Module\DemoExtendSymfonyForm\Entity\SupplierExtraImage

--- a/demoextendgrid/demoextendgrid.php
+++ b/demoextendgrid/demoextendgrid.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+declare(strict_types=1);
+
+use PrestaShop\Module\DemoExtendSymfonyForm\Install\Installer;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+require_once __DIR__.'/vendor/autoload.php';
+
+/**
+ * Class demoextendsymfonyform
+ */
+class DemoExtendGrid extends Module
+{
+    public function __construct()
+    {
+        $this->name = 'demoextendsymfonyform2';
+        $this->author = 'PrestaShop';
+        $this->version = '1.0.0';
+        $this->ps_versions_compliancy = ['min' => '1.7.7.0', 'max' => _PS_VERSION_];
+
+        parent::__construct();
+
+        $this->displayName = $this->l('Demo Symfony Forms #2');
+        $this->description = $this->l('Demonstration of how to add an image upload field inside the Symfony form');
+    }
+
+    /**
+     * @return bool
+     */
+    public function install()
+    {
+        if (!parent::install()) {
+            return false;
+        }
+
+        $installer = new Installer();
+
+        return $installer->install($this);
+    }
+
+    /**
+     * @return bool
+     */
+    public function uninstall()
+    {
+        $installer = new Installer();
+
+        return $installer->uninstall() && parent::uninstall();
+    }
+
+
+}

--- a/demoextendgrid/demoextendgrid.php
+++ b/demoextendgrid/demoextendgrid.php
@@ -10,7 +10,12 @@
 
 declare(strict_types=1);
 
-use PrestaShop\Module\DemoExtendSymfonyForm\Install\Installer;
+use PrestaShop\Module\DemoExtendGrid\Install\Installer;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnInterface;
+use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Exception\ColumnNotFoundException;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -18,22 +23,19 @@ if (!defined('_PS_VERSION_')) {
 
 require_once __DIR__.'/vendor/autoload.php';
 
-/**
- * Class demoextendsymfonyform
- */
 class DemoExtendGrid extends Module
 {
     public function __construct()
     {
-        $this->name = 'demoextendsymfonyform2';
+        $this->name = 'demoextendgrid';
         $this->author = 'PrestaShop';
         $this->version = '1.0.0';
         $this->ps_versions_compliancy = ['min' => '1.7.7.0', 'max' => _PS_VERSION_];
 
         parent::__construct();
 
-        $this->displayName = $this->l('Demo Symfony Forms #2');
-        $this->description = $this->l('Demonstration of how to add an image upload field inside the Symfony form');
+        $this->displayName = $this->l('Demo extend grid');
+        $this->description = $this->l('Demonstration of how to extend grids');
     }
 
     /**
@@ -51,14 +53,39 @@ class DemoExtendGrid extends Module
     }
 
     /**
-     * @return bool
+     * @param array $params
      */
-    public function uninstall()
+    public function hookActionOrderGridDefinitionModifier(array $params): void
     {
-        $installer = new Installer();
+        /** @var GridDefinitionInterface $orderGridDefinition */
+        $orderGridDefinition = $params['definition'];
 
-        return $installer->uninstall() && parent::uninstall();
+        /** @var RowActionCollectionInterface $actionsCollection */
+        $actionsCollection = $this->getActionsColumn($orderGridDefinition)->getOption('actions');
+        $actionsCollection->add(
+            // mark order is just an example of some custom action
+            (new SubmitRowAction('mark_order'))
+                ->setName($this->trans('Mark', [], 'Admin.Actions'))
+                ->setIcon('push_pin')
+                ->setOptions([
+                    'route' => 'demo_admin_orders_mark_order',
+                    'route_param_name' => 'orderId',
+                    'route_param_field' => 'id_order',
+                    // use this if you want to show the action inline instead of adding it to dropdown
+                    'use_inline_display' => true,
+                ])
+        );
+        //@todo: actually button is not working yet, because javascript part is missing (SubmitRowActionExtension)
     }
 
-
+    private function getActionsColumn(GridDefinitionInterface $gridDefinition): ColumnInterface
+    {
+        try {
+            return $gridDefinition->getColumnById('actions');
+        } catch (ColumnNotFoundException $e) {
+            // It is possible that not every grid will have actions column.
+            // In this case you can create a new column or throw exception depending on your needs
+            throw $e;
+        }
+    }
 }

--- a/demoextendgrid/src/Controller/DemoOrderController.php
+++ b/demoextendgrid/src/Controller/DemoOrderController.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\DemoExtendGrid\FrameworkBundleAdminController;
+
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use Symfony\Component\HttpFoundation\Response;
+
+class DemoOrderController extends FrameworkBundleAdminController
+{
+    /**
+     * @param int $orderId
+     *
+     * @return Response
+     */
+    public function markOrderAction(int $orderId): Response
+    {
+        // Do what you need depending on use case
+        $this->addFlash('success', $this->trans('Order was successfully marked', 'Admin.Catalog.Orders'));
+
+        return $this->redirectToRoute('admin_orders_index');
+    }
+}

--- a/demoextendgrid/src/Install/Installer.php
+++ b/demoextendgrid/src/Install/Installer.php
@@ -10,7 +10,7 @@
 
 declare(strict_types=1);
 
-namespace PrestaShop\Module\DemoExtendSymfonyForm\Install;
+namespace PrestaShop\Module\DemoExtendGrid\Install;
 
 use Db;
 use Module;
@@ -30,41 +30,7 @@ class Installer
             return false;
         }
 
-        if (!$this->installDatabase()) {
-            return false;
-        }
-
         return true;
-    }
-
-    /**
-     * Module's uninstallation entry point.
-     *
-     * @return bool
-     */
-    public function uninstall(): bool
-    {
-        return $this->uninstallDatabase();
-    }
-
-    /**
-     * Install the database modifications required for this module.
-     *
-     * @return bool
-     */
-    private function installDatabase(): bool
-    {
-        return $this->executeQueries(SqlQueries::installQueries());
-    }
-
-    /**
-     * Uninstall database modifications.
-     *
-     * @return bool
-     */
-    private function uninstallDatabase(): bool
-    {
-        return $this->executeQueries(SqlQueries::uninstallQueries());
     }
 
     /**
@@ -77,9 +43,7 @@ class Installer
     private function registerHooks(Module $module): bool
     {
         $hooks = [
-            'actionSupplierFormBuilderModifier',
-            'actionAfterCreateSupplierFormHandler',
-            'actionAfterUpdateSupplierFormHandler',
+            'actionOrderGridDefinitionModifier',
         ];
 
         return (bool) $module->registerHook($hooks);

--- a/demoextendgrid/src/Install/Installer.php
+++ b/demoextendgrid/src/Install/Installer.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\DemoExtendSymfonyForm\Install;
+
+use Db;
+use Module;
+
+class Installer
+{
+    /**
+     * Module's installation entry point.
+     *
+     * @param Module $module
+     *
+     * @return bool
+     */
+    public function install(Module $module): bool
+    {
+        if (!$this->registerHooks($module)) {
+            return false;
+        }
+
+        if (!$this->installDatabase()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Module's uninstallation entry point.
+     *
+     * @return bool
+     */
+    public function uninstall(): bool
+    {
+        return $this->uninstallDatabase();
+    }
+
+    /**
+     * Install the database modifications required for this module.
+     *
+     * @return bool
+     */
+    private function installDatabase(): bool
+    {
+        return $this->executeQueries(SqlQueries::installQueries());
+    }
+
+    /**
+     * Uninstall database modifications.
+     *
+     * @return bool
+     */
+    private function uninstallDatabase(): bool
+    {
+        return $this->executeQueries(SqlQueries::uninstallQueries());
+    }
+
+    /**
+     * Register hooks for the module.
+     *
+     * @param Module $module
+     *
+     * @return bool
+     */
+    private function registerHooks(Module $module): bool
+    {
+        $hooks = [
+            'actionSupplierFormBuilderModifier',
+            'actionAfterCreateSupplierFormHandler',
+            'actionAfterUpdateSupplierFormHandler',
+        ];
+
+        return (bool) $module->registerHook($hooks);
+    }
+
+    /**
+     * A helper that executes multiple database queries.
+     *
+     * @param array $queries
+     *
+     * @return bool
+     */
+    private function executeQueries(array $queries): bool
+    {
+        foreach ($queries as $query) {
+            if (!Db::getInstance()->execute($query)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | module could be used to demonstrate grid extension principles. Current PR just adds demonstration of how to extend grid Actions (Is a complementary code to assure #22284 works as expected)
| Type?         | improvement 
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | related to #823 and #22284
| How to test?  | put this module in branch of #22284. Go to Sell > Orders check that list contains additional action in each row with a "pin" icon. :warning: the action still doesn't work because of missing javascript extension related to https://github.com/PrestaShop/ADR/blob/master/0009-expose-js-components-using-window-variable.md

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
