### PR TITLE
Demonstrate displayOrderPreview

### DIFF
--- a/demovieworderhooks/README.md
+++ b/demovieworderhooks/README.md
@@ -11,6 +11,7 @@ It uses the following hooks:
 - displayAdminOrderSideBottom
 - displayAdminOrder
 - displayAdminOrderTop
+- displayOrderPreview
 - actionGetAdminOrderButtons
 
 Please note this module is an example only, not a mandatory structure.
@@ -64,6 +65,10 @@ The listing displays other orders from the same customer.
 
 We use this hook to display blue previous/next order buttons in the top to ease the navigation.
 Please note Order page already contains these buttons, but we put some additional buttons even easier to spot.
+
+### displayOrderPreview
+
+We use this hook on orders list, it's available in quick preview of the order after clicking a little blue arrow next to order ID.
 
 ### actionGetAdminOrderButtons
 

--- a/demovieworderhooks/demovieworderhooks.php
+++ b/demovieworderhooks/demovieworderhooks.php
@@ -224,6 +224,16 @@ class DemoViewOrderHooks extends Module
     }
 
     /**
+     * Displays placeholder text in quick order preview.
+     */
+    public function hookDisplayOrderPreview(array $params)
+    {
+        $orderId = $params['order_id']; // access to id of the order
+
+        return (new joshtronic\LoremIpsum())->sentence();
+    }
+
+    /**
      * Displays previous/next order buttons.
      */
     public function hookDisplayAdminOrderTop(array $params)

--- a/demovieworderhooks/src/Install/Installer.php
+++ b/demovieworderhooks/src/Install/Installer.php
@@ -133,6 +133,7 @@ class Installer
             'displayAdminOrderSide',
             'displayAdminOrderSideBottom',
             'displayAdminOrder',
+            'displayOrderPreview',
             'displayAdminOrderTop',
             'actionGetAdminOrderButtons',
         ];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | title says it all, dunno if we can add it here as module name is "order **view**" but I thought that it would be good to show people how to add something to order preview
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | n/a
| Possible impacts? | n/a

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

![image](https://user-images.githubusercontent.com/2137763/104306140-deec7780-54cd-11eb-9058-461a1836bacc.png)

