### PR TITLE
Copy demoextendsymfonyform1 into demoextendsymfonyform3

### DIFF
--- a/demoextendsymfonyform3/.gitignore
+++ b/demoextendsymfonyform3/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+.idea
+js/node_modules

--- a/demoextendsymfonyform3/README.md
+++ b/demoextendsymfonyform3/README.md
@@ -1,0 +1,37 @@
+# Demonstration of how to use CQRS in a module
+
+## About
+
+This module adds a new field to Customer: a yes/no field "is allowed to review".
+This new field appears:
+- in the Customers listing as a new column
+- in the Customers Add/Edit form as a new field you can manage
+
+This modules demonstrates
+ - how to add this field, manage its content and its
+properties using modern hooks in Symfony pages
+ - how to use custom [CQRS](https://devdocs.prestashop.com/1.7/development/architecture/domain/cqrs/) Commands and Queries to separate your domain from your application
+ - how to use Translator inside modern Symfony module
+
+*This part is demonstrated as a possibility for your module, this is
+not mandatory to be done this way.
+
+ ### Supported PrestaShop versions
+
+ This module is compatible with and 1.7.6.0 and above versions.
+ 
+ ### Requirements
+ 
+  1. Composer, see [Composer](https://getcomposer.org/) to learn more
+ 
+ ### How to install
+ 
+  1. Download or clone module into `modules` directory of your PrestaShop installation
+  2. Rename the directory to make sure that module directory is named `demoextendsymfonyform3`*
+  3. `cd` into module's directory and run following commands:
+      - `composer install` - to download dependencies into vendor folder
+  4. Install module from Back Office
+ 
+ *Because the name of the directory and the name of the main module file must match.
+ 
+

--- a/demoextendsymfonyform3/composer.json
+++ b/demoextendsymfonyform3/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "prestashop/democqrshooksusage",
+  "description": "Help developers to understand how to create module using new hooks and apply best practices when using CQRS",
+  "autoload": {
+    "psr-4": {
+      "DemoCQRSHooksUsage\\": "src/"
+    }
+  },
+  "license": "MIT",
+  "type": "prestashop-module"
+}

--- a/demoextendsymfonyform3/composer.json
+++ b/demoextendsymfonyform3/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "prestashop/democqrshooksusage",
+  "name": "prestashop/demoextendsymfonyform3",
   "description": "Help developers to understand how to create module using new hooks and apply best practices when using CQRS",
   "autoload": {
     "psr-4": {

--- a/demoextendsymfonyform3/config/routes.yml
+++ b/demoextendsymfonyform3/config/routes.yml
@@ -1,0 +1,8 @@
+# @see https://devdocs.prestashop.com/1.7/modules/concepts/controllers/admin-controllers/#how-to-map-an-action-of-your-controller-to-a-uri
+ps_democqrshooksusage_toggle_is_allowed_for_review:
+  path: demo-cqrs-hook-usage/{customerId}/toggle-is-allowed-for-review
+  methods: [POST]
+  defaults:
+    _controller: 'DemoCQRSHooksUsage\Controller\Admin\CustomerReviewController::toggleIsAllowedForReviewAction'
+  requirements:
+    customerId: \d+

--- a/demoextendsymfonyform3/config/services.yml
+++ b/demoextendsymfonyform3/config/services.yml
@@ -1,0 +1,33 @@
+services:
+  _defaults:
+    public: true
+#  @see  https://devdocs.prestashop.com/1.7/development/architecture/migration-guide/forms/cqrs-usage-in-forms/ for CQRS pattern usage examples.
+  democqrshooksusage.domain.reviewer.command_handler.toggle_is_allowed_to_review_handler:
+    class: 'DemoCQRSHooksUsage\Domain\Reviewer\CommandHandler\ToggleIsAllowedToReviewHandler'
+    arguments:
+      - '@democqrshooksusage.repository.reviewer'
+    tags:
+      - name: tactician.handler
+        command: 'DemoCQRSHooksUsage\Domain\Reviewer\Command\ToggleIsAllowedToReviewCommand'
+
+  democqrshooksusage.domain.reviewer.query_handler.get_reviewer_settings_for_form_handler:
+    class: 'DemoCQRSHooksUsage\Domain\Reviewer\QueryHandler\GetReviewerSettingsForFormHandler'
+    arguments:
+      - '@democqrshooksusage.repository.reviewer'
+    tags:
+      - name: tactician.handler
+        command: 'DemoCQRSHooksUsage\Domain\Reviewer\Query\GetReviewerSettingsForForm'
+
+  democqrshooksusage.domain.reviewer.command_handler.update_is_allowed_to_review_handler:
+    class: 'DemoCQRSHooksUsage\Domain\Reviewer\CommandHandler\UpdateIsAllowedToReviewHandler'
+    arguments:
+      - '@democqrshooksusage.repository.reviewer'
+    tags:
+      - name: tactician.handler
+        command: 'DemoCQRSHooksUsage\Domain\Reviewer\Command\UpdateIsAllowedToReviewCommand'
+
+  democqrshooksusage.repository.reviewer:
+    class: 'DemoCQRSHooksUsage\Repository\ReviewerRepository'
+    arguments:
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'

--- a/demoextendsymfonyform3/demoextendsymfonyform3.php
+++ b/demoextendsymfonyform3/demoextendsymfonyform3.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+use DemoCQRSHooksUsage\Domain\Reviewer\Command\UpdateIsAllowedToReviewCommand;
+use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotCreateReviewerException;
+use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotToggleAllowedToReviewStatusException;
+use DemoCQRSHooksUsage\Domain\Reviewer\Exception\ReviewerException;
+use DemoCQRSHooksUsage\Domain\Reviewer\Query\GetReviewerSettingsForForm;
+use DemoCQRSHooksUsage\Domain\Reviewer\QueryResult\ReviewerSettingsForForm;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
+use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
+use PrestaShop\PrestaShop\Core\Search\Filters\CustomerFilters;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+
+/**
+ * Class DemoExtendSymfonyForm1 demonstrates the usage of CQRS pattern and hooks.
+ */
+class DemoExtendSymfonyForm3 extends Module
+{
+    public function __construct()
+    {
+        $this->name = 'demoextendsymfonyform3';
+        $this->version = '1.0.0';
+        $this->author = 'Mathieu Ferment';
+        $this->need_instance = 0;
+
+        parent::__construct();
+
+        $this->displayName = $this->getTranslator()->trans(
+            'Demo Symfony Forms #3',
+            [],
+            'Modules.Democqrshooksusage.Admin'
+        );
+
+        $this->description =
+            $this->getTranslator()->trans(
+                'Help developers to understand how to create module using CQRS',
+                [],
+                'Modules.Democqrshooksusage.Admin'
+            );
+
+        $this->ps_versions_compliancy = [
+            'min' => '1.7.6.0',
+            'max' => _PS_VERSION_,
+        ];
+    }
+
+    /**
+     * This function is required in order to make module compatible with new translation system.
+     *
+     * @return bool
+     */
+    public function isUsingNewTranslationSystem()
+    {
+        return true;
+    }
+
+    /**
+     * Install module and register hooks to allow grid modification.
+     *
+     * @see https://devdocs.prestashop.com/1.7/modules/concepts/hooks/use-hooks-on-modern-pages/
+     *
+     * @return bool
+     */
+    public function install()
+    {
+        return parent::install() &&
+            // Register hook to allow Customer grid definition modifications.
+            // Each grid's definition modification hook has it's own name. Hook name is built using
+            // this structure: "action{grid_id}GridDefinitionModifier", in this case "grid_id" is "customer"
+            // this means we will be modifying "Sell > Customers" page grid.
+            // You can check any definition factory service in PrestaShop\PrestaShop\Core\Grid\Definition\Factory
+            // to see available grid ids. Grid id is returned by `getId()` method.
+            $this->registerHook('actionCustomerGridDefinitionModifier') &&
+            // Register hook to allow Customer grid query modifications which allows to add any sql condition.
+            $this->registerHook('actionCustomerGridQueryBuilderModifier') &&
+            // Register hook to allow overriding customer form
+            // this structure: "action{block_prefix}FormBuilderModifier", in this case "block_prefix" is "customer"
+            // {block_prefix} is either retrieved automatically by its type. E.g "ManufacturerType" will be "manufacturer"
+            // or it can be modified in form type by overriding "getBlockPrefix" function
+            $this->registerHook('actionCustomerFormBuilderModifier') &&
+            $this->registerHook('actionAfterCreateCustomerFormHandler') &&
+            $this->registerHook('actionAfterUpdateCustomerFormHandler') &&
+            $this->installTables()
+            ;
+    }
+
+    public function uninstall()
+    {
+        return parent::uninstall() && $this->uninstallTables();
+    }
+
+    /**
+     * Hook allows to modify Customers grid definition.
+     * This hook is a right place to add/remove columns or actions (bulk, grid).
+     *
+     * @param array $params
+     */
+    public function hookActionCustomerGridDefinitionModifier(array $params)
+    {
+        /** @var GridDefinitionInterface $definition */
+        $definition = $params['definition'];
+
+        $translator = $this->getTranslator();
+
+        $definition
+            ->getColumns()
+            ->addAfter(
+                'optin',
+                (new ToggleColumn('is_allowed_for_review'))
+                    ->setName($translator->trans('Allowed for review', [], 'Modules.Democqrshooksusage.Admin'))
+                    ->setOptions([
+                        'field' => 'is_allowed_for_review',
+                        'primary_field' => 'id_customer',
+                        'route' => 'ps_democqrshooksusage_toggle_is_allowed_for_review',
+                        'route_param_name' => 'customerId',
+                    ])
+            )
+        ;
+
+        $definition->getFilters()->add(
+            (new Filter('is_allowed_for_review', YesAndNoChoiceType::class))
+                ->setAssociatedColumn('is_allowed_for_review')
+        );
+    }
+
+    /**
+     * Hook allows to modify Customers query builder and add custom sql statements.
+     *
+     * @param array $params
+     */
+    public function hookActionCustomerGridQueryBuilderModifier(array $params)
+    {
+        /** @var QueryBuilder $searchQueryBuilder */
+        $searchQueryBuilder = $params['search_query_builder'];
+
+        /** @var CustomerFilters $searchCriteria */
+        $searchCriteria = $params['search_criteria'];
+
+        $searchQueryBuilder->addSelect(
+            'IF(dcur.`is_allowed_for_review` IS NULL,0,dcur.`is_allowed_for_review`) AS `is_allowed_for_review`'
+        );
+
+        $searchQueryBuilder->leftJoin(
+            'c',
+            '`' . pSQL(_DB_PREFIX_) . 'democqrshooksusage_reviewer`',
+            'dcur',
+            'dcur.`id_customer` = c.`id_customer`'
+        );
+
+        if ('is_allowed_for_review' === $searchCriteria->getOrderBy()) {
+            $searchQueryBuilder->orderBy('dcur.`is_allowed_for_review`', $searchCriteria->getOrderWay());
+        }
+
+        foreach ($searchCriteria->getFilters() as $filterName => $filterValue) {
+            if ('is_allowed_for_review' === $filterName) {
+                $searchQueryBuilder->andWhere('dcur.`is_allowed_for_review` = :is_allowed_for_review');
+                $searchQueryBuilder->setParameter('is_allowed_for_review', $filterValue);
+
+                if (!$filterValue) {
+                    $searchQueryBuilder->orWhere('dcur.`is_allowed_for_review` IS NULL');
+                }
+            }
+        }
+    }
+
+    /**
+     * Hook allows to modify Customers form and add additional form fields as well as modify or add new data to the forms.
+     *
+     * @param array $params
+     */
+    public function hookActionCustomerFormBuilderModifier(array $params)
+    {
+        /** @var FormBuilderInterface $formBuilder */
+        $formBuilder = $params['form_builder'];
+        $formBuilder->add('is_allowed_for_review', SwitchType::class, [
+            'label' => $this->getTranslator()->trans('Allow reviews', [], 'Modules.Democqrshooksusage.Admin'),
+            'required' => false,
+        ]);
+
+        /**
+         * @var CommandBusInterface
+         */
+        $queryBus = $this->get('prestashop.core.query_bus');
+
+        /**
+         * This part demonstrates the usage of CQRS pattern query to perform read operation from Reviewer entity.
+         *
+         * @see https://devdocs.prestashop.com/1.7/development/architecture/cqrs/ for more detailed information.
+         *
+         * As this is our recommended approach of reading the data but we not force to use this pattern in modules -
+         * you can use directly an entity here or wrap it in custom service class.
+         *
+         * @var ReviewerSettingsForForm
+         */
+        $reviewerSettings = $queryBus->handle(new GetReviewerSettingsForForm($params['id']));
+
+        $params['data']['is_allowed_for_review'] = $reviewerSettings->isAllowedForReview();
+
+        $formBuilder->setData($params['data']);
+    }
+
+    /**
+     * Hook allows to modify Customers form and add additional form fields as well as modify or add new data to the forms.
+     *
+     * @param array $params
+     *
+     * @throws CustomerException
+     */
+    public function hookActionAfterUpdateCustomerFormHandler(array $params)
+    {
+        $this->updateCustomerReviewStatus($params);
+    }
+
+    /**
+     * Hook allows to modify Customers form and add additional form fields as well as modify or add new data to the forms.
+     *
+     * @param array $params
+     *
+     * @throws CustomerException
+     */
+    public function hookActionAfterCreateCustomerFormHandler(array $params)
+    {
+        $this->updateCustomerReviewStatus($params);
+    }
+
+    /**
+     * @param array $params
+     *
+     * @throws \PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorException
+     */
+    private function updateCustomerReviewStatus(array $params)
+    {
+        $customerId = $params['id'];
+        /** @var array $customerFormData */
+        $customerFormData = $params['form_data'];
+        $isAllowedForReview = (bool) $customerFormData['is_allowed_for_review'];
+
+        /** @var CommandBusInterface $commandBus */
+        $commandBus = $this->get('prestashop.core.command_bus');
+
+        try {
+            /*
+             * This part demonstrates the usage of CQRS pattern command to perform write operation for Reviewer entity.
+             * @see https://devdocs.prestashop.com/1.7/development/architecture/cqrs/ for more detailed information.
+             *
+             * As this is our recommended approach of writing the data but we not force to use this pattern in modules -
+             * you can use directly an entity here or wrap it in custom service class.
+             */
+            $commandBus->handle(new UpdateIsAllowedToReviewCommand(
+                $customerId,
+                $isAllowedForReview
+            ));
+        } catch (ReviewerException $exception) {
+            $this->handleException($exception);
+        }
+    }
+
+    /**
+     * Installs sample tables required for demonstration.
+     *
+     * @return bool
+     */
+    private function installTables()
+    {
+        $sql = '
+            CREATE TABLE IF NOT EXISTS `' . pSQL(_DB_PREFIX_) . 'democqrshooksusage_reviewer` (
+                `id_reviewer` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+                `id_customer` INT(10) UNSIGNED NOT NULL,
+                `is_allowed_for_review` TINYINT(1) NOT NULL,
+                PRIMARY KEY (`id_reviewer`)
+            ) ENGINE=' . pSQL(_MYSQL_ENGINE_) . ' COLLATE=utf8_unicode_ci;
+        ';
+
+        return Db::getInstance()->execute($sql);
+    }
+
+    /**
+     * Uninstalls sample tables required for demonstration.
+     *
+     * @return bool
+     */
+    private function uninstallTables()
+    {
+        $sql = 'DROP TABLE IF EXISTS `' . pSQL(_DB_PREFIX_) . 'democqrshooksusage_reviewer`';
+
+        return Db::getInstance()->execute($sql);
+    }
+
+    /**
+     * Handles exceptions and displays message in more user friendly form.
+     *
+     * @param ReviewerException $exception
+     *
+     * @throws \PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorException
+     */
+    private function handleException(ReviewerException $exception)
+    {
+        $exceptionDictionary = [
+            CannotCreateReviewerException::class => $this->getTranslator()->trans(
+                'Failed to create a record for customer',
+                [],
+                'Modules.Democqrshooksusage.Admin'
+            ),
+            CannotToggleAllowedToReviewStatusException::class => $this->getTranslator()->trans(
+                'Failed to toggle is allowed to review status',
+                [],
+                'Modules.Democqrshooksusage.Admin'
+            ),
+        ];
+
+        $exceptionType = get_class($exception);
+
+        if (isset($exceptionDictionary[$exceptionType])) {
+            $message = $exceptionDictionary[$exceptionType];
+        } else {
+            $message = $this->getTranslator()->trans(
+                'An unexpected error occurred. [%type% code %code%]',
+                [
+                    '%type%' => $exceptionType,
+                    '%code%' => $exception->getCode(),
+                ],
+                'Admin.Notifications.Error'
+            );
+        }
+
+        throw new \PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorException($message);
+    }
+}

--- a/demoextendsymfonyform3/src/Controller/Admin/CustomerReviewController.php
+++ b/demoextendsymfonyform3/src/Controller/Admin/CustomerReviewController.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Controller\Admin;
+
+use DemoCQRSHooksUsage\Domain\Reviewer\Command\ToggleIsAllowedToReviewCommand;
+use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotCreateReviewerException;
+use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotToggleAllowedToReviewStatusException;
+use DemoCQRSHooksUsage\Domain\Reviewer\Exception\ReviewerException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * This controller holds all custom actions which are added by extending "Sell > Customers" page.
+ *
+ * @see https://devdocs.prestashop.com/1.7/modules/concepts/controllers/admin-controllers/ for more details.
+ */
+class CustomerReviewController extends FrameworkBundleAdminController
+{
+    /**
+     * Catches the toggle action of customer review.
+     *
+     * @param int $customerId
+     *
+     * @return RedirectResponse
+     */
+    public function toggleIsAllowedForReviewAction($customerId)
+    {
+        try {
+            /*
+             * This part demonstrates the usage of CQRS pattern command to perform write operation for Reviewer entity.
+             * @see https://devdocs.prestashop.com/1.7/development/architecture/cqrs/ for more detailed information.
+             *
+             * As this is our recommended approach of writing the data but we not force to use this pattern in modules -
+             * you can use directly an entity here or wrap it in custom service class.
+             */
+            $this->getCommandBus()->handle(new ToggleIsAllowedToReviewCommand((int) $customerId));
+
+            $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+        } catch (ReviewerException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessageMapping()));
+        }
+
+        return $this->redirectToRoute('admin_customers_index');
+    }
+
+    /**
+     * Gets error message mappings which are later used to display friendly user error message instead of the
+     * exception message.
+     *
+     * @see https://devdocs.prestashop.com/1.7/development/architecture/domain-exceptions/ for more detailed explanation
+     *
+     * @return array
+     */
+    private function getErrorMessageMapping()
+    {
+        return [
+            CustomerException::class => $this->trans(
+                'Something bad happened when trying to get customer id',
+                'Modules.Democqrshooksusage.Customerreviewcontroller'
+            ),
+            CannotCreateReviewerException::class => $this->trans(
+                'Failed to create reviewer',
+                'Modules.Democqrshooksusage.Customerreviewcontroller'
+            ),
+            CannotToggleAllowedToReviewStatusException::class => $this->trans(
+                'An error occurred while updating the status.',
+                'Modules.Democqrshooksusage.Customerreviewcontroller'
+            ),
+        ];
+    }
+}

--- a/demoextendsymfonyform3/src/Domain/Reviewer/Command/ToggleIsAllowedToReviewCommand.php
+++ b/demoextendsymfonyform3/src/Domain/Reviewer/Command/ToggleIsAllowedToReviewCommand.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Domain\Reviewer\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
+
+/**
+ * Used for toggling the customer if is allowed to make a review.
+ *
+ * @see \DemoCQRSHooksUsage\Domain\Reviewer\CommandHandler\ToggleIsAllowedToReviewHandler how the data is handled.
+ */
+class ToggleIsAllowedToReviewCommand
+{
+    /**
+     * @var CustomerId
+     */
+    private $customerId;
+
+    /**
+     * @param int $customerId
+     *
+     * @throws CustomerException
+     */
+    public function __construct($customerId)
+    {
+        $this->customerId = new CustomerId($customerId);
+    }
+
+    /**
+     * @return CustomerId
+     */
+    public function getCustomerId()
+    {
+        return $this->customerId;
+    }
+}

--- a/demoextendsymfonyform3/src/Domain/Reviewer/Command/UpdateIsAllowedToReviewCommand.php
+++ b/demoextendsymfonyform3/src/Domain/Reviewer/Command/UpdateIsAllowedToReviewCommand.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Domain\Reviewer\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
+
+/**
+ * used to update customers review status.
+ *
+ * @see \DemoCQRSHooksUsage\Domain\Reviewer\CommandHandler\UpdateIsAllowedToReviewHandler how the data is handled.
+ */
+class UpdateIsAllowedToReviewCommand
+{
+    /**
+     * @var CustomerId
+     */
+    private $customerId;
+
+    /**
+     * @var bool
+     */
+    private $isAllowedToReview;
+
+    /**
+     * @param int $customerId
+     * @param bool $isAllowedToReview
+     *
+     * @throws CustomerException
+     */
+    public function __construct($customerId, $isAllowedToReview)
+    {
+        $this->customerId = new CustomerId($customerId);
+        $this->isAllowedToReview = $isAllowedToReview;
+    }
+
+    /**
+     * @return CustomerId
+     */
+    public function getCustomerId()
+    {
+        return $this->customerId;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAllowedToReview()
+    {
+        return $this->isAllowedToReview;
+    }
+}

--- a/demoextendsymfonyform3/src/Domain/Reviewer/CommandHandler/AbstractReviewerHandler.php
+++ b/demoextendsymfonyform3/src/Domain/Reviewer/CommandHandler/AbstractReviewerHandler.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Domain\Reviewer\CommandHandler;
+
+use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotCreateReviewerException;
+use DemoCQRSHooksUsage\Entity\Reviewer;
+
+/**
+ * Holds the abstraction for common actions for reviewer commands.
+ */
+class AbstractReviewerHandler
+{
+    /**
+     * Creates a reviewer.
+     *
+     * @param $customerId
+     *
+     * @return Reviewer
+     *
+     * @throws CannotCreateReviewerException
+     */
+    protected function createReviewer($customerId)
+    {
+        try {
+            $reviewer = new Reviewer();
+            $reviewer->id_customer = $customerId;
+            $reviewer->is_allowed_for_review = 0;
+
+            if (false === $reviewer->save()) {
+                throw new CannotCreateReviewerException(
+                    sprintf(
+                        'An error occurred when creating reviewer with customer id "%s"',
+                        $customerId
+                    )
+                );
+            }
+        } catch (PrestaShopException $exception) {
+            /*
+             * @see https://devdocs.prestashop.com/1.7/development/architecture/domain-exceptions/
+             */
+            throw new CannotCreateReviewerException(
+                sprintf(
+                    'An unexpected error occurred when creating reviewer with customer id "%s"',
+                    $customerId
+                ),
+                0,
+                $exception
+            );
+        }
+
+        return $reviewer;
+    }
+}

--- a/demoextendsymfonyform3/src/Domain/Reviewer/CommandHandler/ToggleIsAllowedToReviewHandler.php
+++ b/demoextendsymfonyform3/src/Domain/Reviewer/CommandHandler/ToggleIsAllowedToReviewHandler.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Domain\Reviewer\CommandHandler;
+
+use DemoCQRSHooksUsage\Domain\Reviewer\Command\ToggleIsAllowedToReviewCommand;
+use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotCreateReviewerException;
+use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotToggleAllowedToReviewStatusException;
+use DemoCQRSHooksUsage\Entity\Reviewer;
+use DemoCQRSHooksUsage\Repository\ReviewerRepository;
+use PrestaShopException;
+
+/**
+ * Used for toggling the customer if is allowed to make a review.
+ */
+class ToggleIsAllowedToReviewHandler extends AbstractReviewerHandler
+{
+    /**
+     * @var ReviewerRepository
+     */
+    private $reviewerRepository;
+
+    /**
+     * @param ReviewerRepository $reviewerRepository
+     */
+    public function __construct(ReviewerRepository $reviewerRepository)
+    {
+        $this->reviewerRepository = $reviewerRepository;
+    }
+
+    /**
+     * @param ToggleIsAllowedToReviewCommand $command
+     *
+     * @throws CannotCreateReviewerException
+     * @throws CannotToggleAllowedToReviewStatusException
+     */
+    public function handle(ToggleIsAllowedToReviewCommand $command)
+    {
+        $reviewerId = $this->reviewerRepository->findIdByCustomer($command->getCustomerId()->getValue());
+
+        $reviewer = new Reviewer($reviewerId);
+
+        if (0 >= $reviewer->id) {
+            $reviewer = $this->createReviewer($command->getCustomerId()->getValue());
+        }
+
+        $reviewer->is_allowed_for_review = (bool) !$reviewer->is_allowed_for_review;
+
+        try {
+            if (false === $reviewer->update()) {
+                throw new CannotToggleAllowedToReviewStatusException(
+                    sprintf('Failed to change status for reviewer with id "%s"', $reviewer->id)
+                );
+            }
+        } catch (PrestaShopException $exception) {
+            /*
+             * @see https://devdocs.prestashop.com/1.7/development/architecture/domain-exceptions/
+             */
+            throw new CannotToggleAllowedToReviewStatusException(
+                'An unexpected error occurred when updating reviewer status'
+            );
+        }
+    }
+}

--- a/demoextendsymfonyform3/src/Domain/Reviewer/CommandHandler/UpdateIsAllowedToReviewHandler.php
+++ b/demoextendsymfonyform3/src/Domain/Reviewer/CommandHandler/UpdateIsAllowedToReviewHandler.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Domain\Reviewer\CommandHandler;
+
+use DemoCQRSHooksUsage\Domain\Reviewer\Command\UpdateIsAllowedToReviewCommand;
+use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotToggleAllowedToReviewStatusException;
+use DemoCQRSHooksUsage\Entity\Reviewer;
+use DemoCQRSHooksUsage\Repository\ReviewerRepository;
+use PrestaShopException;
+
+/**
+ * used to update customers review status.
+ */
+class UpdateIsAllowedToReviewHandler extends AbstractReviewerHandler
+{
+    /**
+     * @var ReviewerRepository
+     */
+    private $reviewerRepository;
+
+    /**
+     * @param ReviewerRepository $reviewerRepository
+     */
+    public function __construct(ReviewerRepository $reviewerRepository)
+    {
+        $this->reviewerRepository = $reviewerRepository;
+    }
+
+    public function handle(UpdateIsAllowedToReviewCommand $command)
+    {
+        $reviewerId = $this->reviewerRepository->findIdByCustomer($command->getCustomerId()->getValue());
+
+        $reviewer = new Reviewer($reviewerId);
+
+        if (0 >= $reviewer->id) {
+            $reviewer = $this->createReviewer($command->getCustomerId()->getValue());
+        }
+
+        $reviewer->is_allowed_for_review = $command->isAllowedToReview();
+
+        try {
+            if (false === $reviewer->update()) {
+                throw new CannotToggleAllowedToReviewStatusException(
+                    sprintf('Failed to change status for reviewer with id "%s"', $reviewer->id)
+                );
+            }
+        } catch (PrestaShopException $exception) {
+            /*
+             * @see https://devdocs.prestashop.com/1.7/development/architecture/domain-exceptions/
+             */
+            throw new CannotToggleAllowedToReviewStatusException(
+                'An unexpected error occurred when updating reviewer status'
+            );
+        }
+    }
+}

--- a/demoextendsymfonyform3/src/Domain/Reviewer/Exception/CannotCreateReviewerException.php
+++ b/demoextendsymfonyform3/src/Domain/Reviewer/Exception/CannotCreateReviewerException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Domain\Reviewer\Exception;
+
+class CannotCreateReviewerException extends ReviewerException
+{
+}

--- a/demoextendsymfonyform3/src/Domain/Reviewer/Exception/CannotToggleAllowedToReviewStatusException.php
+++ b/demoextendsymfonyform3/src/Domain/Reviewer/Exception/CannotToggleAllowedToReviewStatusException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Domain\Reviewer\Exception;
+
+class CannotToggleAllowedToReviewStatusException extends ReviewerException
+{
+}

--- a/demoextendsymfonyform3/src/Domain/Reviewer/Exception/ReviewerException.php
+++ b/demoextendsymfonyform3/src/Domain/Reviewer/Exception/ReviewerException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Domain\Reviewer\Exception;
+
+class ReviewerException extends \Exception
+{
+}

--- a/demoextendsymfonyform3/src/Domain/Reviewer/Query/GetReviewerSettingsForForm.php
+++ b/demoextendsymfonyform3/src/Domain/Reviewer/Query/GetReviewerSettingsForForm.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Domain\Reviewer\Query;
+
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
+
+/**
+ * Gets reviewer settings data ready for form display.
+ *
+ * @see \DemoCQRSHooksUsage\Domain\Reviewer\QueryHandler\GetReviewerSettingsForFormHandler how the data is retrieved.
+ */
+class GetReviewerSettingsForForm
+{
+    /**
+     * @var CustomerId|null
+     */
+    private $customerId;
+
+    /**
+     * @param int|null $customerId
+     */
+    public function __construct($customerId)
+    {
+        $this->customerId = null !== $customerId ? new CustomerId((int) $customerId) : null;
+    }
+
+    /**
+     * @return CustomerId|null
+     */
+    public function getCustomerId()
+    {
+        return $this->customerId;
+    }
+}

--- a/demoextendsymfonyform3/src/Domain/Reviewer/QueryHandler/GetReviewerSettingsForFormHandler.php
+++ b/demoextendsymfonyform3/src/Domain/Reviewer/QueryHandler/GetReviewerSettingsForFormHandler.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Domain\Reviewer\QueryHandler;
+
+use DemoCQRSHooksUsage\Domain\Reviewer\Query\GetReviewerSettingsForForm;
+use DemoCQRSHooksUsage\Domain\Reviewer\QueryResult\ReviewerSettingsForForm;
+use DemoCQRSHooksUsage\Repository\ReviewerRepository;
+
+/**
+ * Gets reviewer settings data ready for form display.
+ */
+class GetReviewerSettingsForFormHandler
+{
+    /**
+     * @var ReviewerRepository
+     */
+    private $reviewerRepository;
+
+    /**
+     * @param ReviewerRepository $reviewerRepository
+     */
+    public function __construct(ReviewerRepository $reviewerRepository)
+    {
+        $this->reviewerRepository = $reviewerRepository;
+    }
+
+    public function handle(GetReviewerSettingsForForm $query)
+    {
+        if (null === $query->getCustomerId()) {
+            return new ReviewerSettingsForForm(false);
+        }
+
+        return new ReviewerSettingsForForm(
+            $this->reviewerRepository->getIsAllowedToReviewStatus($query->getCustomerId()->getValue())
+        );
+    }
+}

--- a/demoextendsymfonyform3/src/Domain/Reviewer/QueryResult/ReviewerSettingsForForm.php
+++ b/demoextendsymfonyform3/src/Domain/Reviewer/QueryResult/ReviewerSettingsForForm.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Domain\Reviewer\QueryResult;
+
+/**
+ * Holds data used in modified customers form.
+ */
+class ReviewerSettingsForForm
+{
+    /**
+     * @var bool
+     */
+    private $isAllowedForReview;
+
+    /**
+     * @param bool $isAllowedForReview
+     */
+    public function __construct($isAllowedForReview)
+    {
+        $this->isAllowedForReview = $isAllowedForReview;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAllowedForReview()
+    {
+        return $this->isAllowedForReview;
+    }
+}

--- a/demoextendsymfonyform3/src/Entity/Reviewer.php
+++ b/demoextendsymfonyform3/src/Entity/Reviewer.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Entity;
+
+use PrestaShop\PrestaShop\Adapter\Entity\ObjectModel;
+
+/**
+ * This entity database state is managed by PrestaShop ObjectModel
+ */
+class Reviewer extends ObjectModel
+{
+    /**
+     * @var int
+     */
+    public $id_customer;
+
+    /**
+     * @var int
+     */
+    public $is_allowed_for_review;
+
+    public static $definition = [
+        'table' => 'democqrshooksusage_reviewer',
+        'primary' => 'id_reviewer',
+        'fields' => [
+            'id_customer' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'],
+            'is_allowed_for_review' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
+        ],
+    ];
+}

--- a/demoextendsymfonyform3/src/Repository/ReviewerRepository.php
+++ b/demoextendsymfonyform3/src/Repository/ReviewerRepository.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * 2007-2020 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+
+namespace DemoCQRSHooksUsage\Repository;
+
+use Doctrine\DBAL\Connection;
+use PDO;
+
+class ReviewerRepository
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $dbPrefix;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     */
+    public function __construct(Connection $connection, $dbPrefix)
+    {
+        $this->connection = $connection;
+        $this->dbPrefix = $dbPrefix;
+    }
+
+    /**
+     * Finds customer id if such exists.
+     *
+     * @param int $customerId
+     *
+     * @return int
+     */
+    public function findIdByCustomer($customerId)
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+
+        $queryBuilder
+            ->select('`id_reviewer`')
+            ->from($this->dbPrefix . 'democqrshooksusage_reviewer')
+            ->where('`id_customer` = :customer_id')
+        ;
+
+        $queryBuilder->setParameter('customer_id', $customerId);
+
+        return (int) $queryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * Gets allowed to review status by customer.
+     *
+     * @param int $customerId
+     *
+     * @return bool
+     */
+    public function getIsAllowedToReviewStatus($customerId)
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+
+        $queryBuilder
+            ->select('`is_allowed_for_review`')
+            ->from($this->dbPrefix . 'democqrshooksusage_reviewer')
+            ->where('`id_customer` = :customer_id')
+        ;
+
+        $queryBuilder->setParameter('customer_id', $customerId);
+
+        return (bool) $queryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | There is confusion about [Demo Symfony Form module 1](https://github.com/PrestaShop/example-modules/tree/master/demoextendsymfonyform1) because the module demonstrates 2 things: how to use a CQRS in a module AND how to use hooks to add new field to a Symfony form<br/><br/>Some community developers think that the two must be together although actually you can choose to use CQRS or not to add new field to a Symfony form.<br/><br/>To fix this I will split this module into 2 demo modules. This PR creates the new module.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes 1 item of https://github.com/PrestaShop/example-modules/issues/32
| How to test?      | No need to test
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
