### PR TITLE
Add other and choice form types to example form

### DIFF
--- a/demosymfonyform/README.md
+++ b/demosymfonyform/README.md
@@ -4,22 +4,25 @@
 
 This module demonstrates how to use existing PrestaShop Symfony form types inside a new page.
 
- ### Supported PrestaShop versions
+It provides two demo pages where all possible [form types](https://symfony.com/doc/current/reference/forms/types.html)
+are being used. You can use these pages as examples of how to integrate these inputs in a module.
 
- This module is compatible with and 1.7.8.0 and above versions.
+### Supported PrestaShop versions
+
+This module is compatible with and 1.7.8.0 and above versions.
  
- ### Requirements
+### Requirements
  
-  1. Composer, see [Composer](https://getcomposer.org/) to learn more
+1. Composer, see [Composer](https://getcomposer.org/) to learn more
  
- ### How to install
+### How to install
  
-  1. Download or clone module into `modules` directory of your PrestaShop installation
-  2. Rename the directory to make sure that module directory is named `demosymfonyform`*
-  3. `cd` into module's directory and run following commands:
-      - `composer install` - to download dependencies into vendor folder
-  4. Install module from Back Office
+1. Download or clone module into `modules` directory of your PrestaShop installation
+2. Rename the directory to make sure that module directory is named `demosymfonyform`*
+3. `cd` into module's directory and run following commands:
+  - `composer install` - to download dependencies into vendor folder
+4. Install module from Back Office
  
- *Because the name of the directory and the name of the main module file must match.
+*Because the name of the directory and the name of the main module file must match.
  
 

--- a/demosymfonyform/composer.json
+++ b/demosymfonyform/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "prestashop/formexamples",
+  "name": "prestashop/demosymfonyform",
   "description": "PrestaShop - Form Examples",
-  "homepage": "https://github.com/PrestaShop/formexamples",
+  "homepage": "https://github.com/PrestaShop/demosymfonyform",
   "license": "AFL - Academic Free License (AFL 3.0)",
   "authors": [
     {

--- a/demosymfonyform/config/index.php
+++ b/demosymfonyform/config/index.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

--- a/demosymfonyform/config/routes.yml
+++ b/demosymfonyform/config/routes.yml
@@ -26,4 +26,3 @@ demo_configuration_other_form_save:
   methods: [ POST ]
   defaults:
     _controller: 'PrestaShop\Module\DemoSymfonyForm\Controller\DemoConfigurationMultipleFormsController::saveOtherForm'
-

--- a/demosymfonyform/config/routes.yml
+++ b/demosymfonyform/config/routes.yml
@@ -6,3 +6,24 @@ demo_configuration_form:
     # Needed to work with tab system
     _legacy_controller: AdminDemoSymfonyForm
     _legacy_link: AdminDemoSymfonyForm
+
+demo_configuration_multiple_forms:
+  path: /demosymfonyform/configurationMultipleForms
+  methods: [GET]
+  defaults:
+    _controller: 'PrestaShop\Module\DemoSymfonyForm\Controller\DemoConfigurationMultipleFormsController::index'
+    _legacy_controller: AdminDemoSymfonyFormMultipleForms
+    _legacy_link: AdminDemoSymfonyFormMultipleForms
+
+demo_configuration_choices_form_save:
+  path: /demosymfonyform/configurationMultipleForms/saveChoices
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShop\Module\DemoSymfonyForm\Controller\DemoConfigurationMultipleFormsController::saveChoicesForm'
+
+demo_configuration_other_form_save:
+  path: /demosymfonyform/configurationMultipleForms/saveOther
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShop\Module\DemoSymfonyForm\Controller\DemoConfigurationMultipleFormsController::saveOtherForm'
+

--- a/demosymfonyform/config/services.yml
+++ b/demosymfonyform/config/services.yml
@@ -27,3 +27,55 @@ services:
   prestashop.module.demosymfonyform.form.demo_configuration_text_data_configuration:
     class: PrestaShop\Module\DemoSymfonyForm\Form\DemoConfigurationTextDataConfiguration
     arguments: ['@prestashop.adapter.legacy.configuration']
+
+  # Demo configuration choice form
+  prestashop.module.demosymfonyform.form.type.demo_configuration_choice:
+    class: 'PrestaShop\Module\DemoSymfonyForm\Form\DemoConfigurationChoiceType'
+    parent: 'form.type.translatable.aware'
+    public: true
+    tags:
+      - { name: form.type }
+
+  prestashop.module.demosymfonyform.form.demo_configuration_choice_form_data_provider:
+    class: 'PrestaShop\Module\DemoSymfonyForm\Form\DemoConfigurationChoiceFormDataProvider'
+    arguments:
+      - '@prestashop.module.demosymfonyform.form.demo_configuration_choice_data_configuration'
+
+  prestashop.module.demosymfonyform.form.demo_configuration_choice_form_data_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.module.demosymfonyform.form.demo_configuration_choice_form_data_provider'
+      - 'PrestaShop\Module\DemoSymfonyForm\Form\DemoConfigurationChoiceType'
+      - 'DemoConfiguration'
+
+  prestashop.module.demosymfonyform.form.demo_configuration_choice_data_configuration:
+    class: PrestaShop\Module\DemoSymfonyForm\Form\DemoConfigurationChoiceDataConfiguration
+    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+
+  # Demo configuration other form
+  prestashop.module.demosymfonyform.form.type.demo_configuration_other:
+    class: 'PrestaShop\Module\DemoSymfonyForm\Form\DemoConfigurationOtherType'
+    parent: 'form.type.translatable.aware'
+    public: true
+    tags:
+      - { name: form.type }
+
+  prestashop.module.demosymfonyform.form.demo_configuration_other_form_data_provider:
+    class: 'PrestaShop\Module\DemoSymfonyForm\Form\DemoConfigurationOtherFormDataProvider'
+    arguments:
+      - '@prestashop.module.demosymfonyform.form.demo_configuration_other_data_configuration'
+
+  prestashop.module.demosymfonyform.form.demo_configuration_other_form_data_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.module.demosymfonyform.form.demo_configuration_other_form_data_provider'
+      - 'PrestaShop\Module\DemoSymfonyForm\Form\DemoConfigurationOtherType'
+      - 'DemoConfiguration'
+
+  prestashop.module.demosymfonyform.form.demo_configuration_other_data_configuration:
+    class: PrestaShop\Module\DemoSymfonyForm\Form\DemoConfigurationOtherDataConfiguration
+    arguments: [ '@prestashop.adapter.legacy.configuration' ]

--- a/demosymfonyform/demosymfonyform.php
+++ b/demosymfonyform/demosymfonyform.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);
@@ -34,7 +28,7 @@ class DemoSymfonyForm extends Module
     {
         $this->name = 'demosymfonyform';
         $this->author = 'PrestaShop';
-        $this->version = '1.0.0';
+        $this->version = '1.1.0';
         $this->need_instance = 0;
 
         $this->bootstrap = true;

--- a/demosymfonyform/demosymfonyform.php
+++ b/demosymfonyform/demosymfonyform.php
@@ -63,7 +63,7 @@ class DemoSymfonyForm extends Module
                 'class_name' => 'AdminDemoSymfonyFormMultipleForms',
                 'visible' => true,
                 'name' => 'Admin symfony form multiple forms',
-                'parent_class_name' => 'Sell',
+                'parent_class_name' => 'CONFIGURE',
             ],
         ];
     }

--- a/demosymfonyform/demosymfonyform.php
+++ b/demosymfonyform/demosymfonyform.php
@@ -59,12 +59,6 @@ class DemoSymfonyForm extends Module
                 'name' => 'Admin symfony form single',
                 'parent_class_name' => 'CONFIGURE',
             ],
-        ];
-    }
-
-    public function getTabs()
-    {
-        return [
             [
                 'class_name' => 'AdminDemoSymfonyFormMultipleForms',
                 'visible' => true,
@@ -73,7 +67,6 @@ class DemoSymfonyForm extends Module
             ],
         ];
     }
-
 
     public function getContent()
     {

--- a/demosymfonyform/demosymfonyform.php
+++ b/demosymfonyform/demosymfonyform.php
@@ -62,6 +62,19 @@ class DemoSymfonyForm extends Module
         ];
     }
 
+    public function getTabs()
+    {
+        return [
+            [
+                'class_name' => 'AdminDemoSymfonyFormMultipleForms',
+                'visible' => true,
+                'name' => 'Admin symfony form multiple forms',
+                'parent_class_name' => 'Sell',
+            ],
+        ];
+    }
+
+
     public function getContent()
     {
         $route = SymfonyContainer::getInstance()->get('router')->generate('demo_configuration_form');

--- a/demosymfonyform/src/Controller/DemoConfigurationController.php
+++ b/demosymfonyform/src/Controller/DemoConfigurationController.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);

--- a/demosymfonyform/src/Controller/DemoConfigurationMultipleFormsController.php
+++ b/demosymfonyform/src/Controller/DemoConfigurationMultipleFormsController.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);

--- a/demosymfonyform/src/Controller/DemoConfigurationMultipleFormsController.php
+++ b/demosymfonyform/src/Controller/DemoConfigurationMultipleFormsController.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\DemoSymfonyForm\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+
+class DemoConfigurationMultipleFormsController extends FrameworkBundleAdminController
+{
+    public function index(Request $request): Response
+    {
+        $choiceFormDataHandler = $this->get('prestashop.module.demosymfonyform.form.demo_configuration_choice_form_data_handler');
+        $choiceForm = $choiceFormDataHandler->getForm();
+        $otherFormDataHandler = $this->get('prestashop.module.demosymfonyform.form.demo_configuration_other_form_data_handler');
+        $otherForm = $otherFormDataHandler->getForm();
+
+        return $this->render('@Modules/demosymfonyform/views/templates/admin/multipleForms.html.twig', [
+            'demoConfigurationChoiceForm' => $choiceForm->createView(),
+            'demoConfigurationOtherForm' => $otherForm->createView(),
+        ]);
+    }
+
+    public function saveChoicesForm(Request $request): Response
+    {
+        $choiceFormDataHandler = $this->get('prestashop.module.demosymfonyform.form.demo_configuration_choice_form_data_handler');
+        $choiceForm = $choiceFormDataHandler->getForm();
+        $choiceForm->handleRequest($request);
+
+        if ($choiceForm->isSubmitted() && $choiceForm->isValid()) {
+            $errors = $choiceFormDataHandler->save($choiceForm->getData());
+
+            if (empty($errors)) {
+                $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+            } else {
+                $this->flashErrors($errors);
+            }
+        }
+        return $this->redirectToRoute('demo_configuration_multiple_forms');
+
+    }
+
+    public function saveOtherForm(Request $request): Response
+    {
+        $otherFormDataHandler = $this->get('prestashop.module.demosymfonyform.form.demo_configuration_other_form_data_handler');
+        $otherForm = $otherFormDataHandler->getForm();
+        $otherForm->handleRequest($request);
+
+        if ($otherForm->isSubmitted() && $otherForm->isValid()) {
+            $errors = $otherFormDataHandler->save($otherForm->getData());
+
+            if (empty($errors)) {
+                $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+            } else {
+                $this->flashErrors($errors);
+            }
+        }
+        return $this->redirectToRoute('demo_configuration_multiple_forms');
+
+    }
+}

--- a/demosymfonyform/src/Controller/DemoConfigurationMultipleFormsController.php
+++ b/demosymfonyform/src/Controller/DemoConfigurationMultipleFormsController.php
@@ -28,9 +28,9 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\DemoSymfonyForm\Controller;
 
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 
 class DemoConfigurationMultipleFormsController extends FrameworkBundleAdminController
 {
@@ -47,13 +47,21 @@ class DemoConfigurationMultipleFormsController extends FrameworkBundleAdminContr
         ]);
     }
 
+    /**
+     * When you have multiple forms in one page it's best to have a separate action/route for saving of the route
+     */
     public function saveChoicesForm(Request $request): Response
     {
         $choiceFormDataHandler = $this->get('prestashop.module.demosymfonyform.form.demo_configuration_choice_form_data_handler');
         $choiceForm = $choiceFormDataHandler->getForm();
         $choiceForm->handleRequest($request);
 
-        if ($choiceForm->isSubmitted() && $choiceForm->isValid()) {
+        /*
+         * Not checking for isValid because form is redirected afterwards,
+         * so even if you won't save because of constraints user won't see it
+         * You can validate form inside dataProvider/configuration
+         */
+        if ($choiceForm->isSubmitted()) {
             $errors = $choiceFormDataHandler->save($choiceForm->getData());
 
             if (empty($errors)) {
@@ -62,8 +70,8 @@ class DemoConfigurationMultipleFormsController extends FrameworkBundleAdminContr
                 $this->flashErrors($errors);
             }
         }
-        return $this->redirectToRoute('demo_configuration_multiple_forms');
 
+        return $this->redirectToRoute('demo_configuration_multiple_forms');
     }
 
     public function saveOtherForm(Request $request): Response
@@ -72,7 +80,7 @@ class DemoConfigurationMultipleFormsController extends FrameworkBundleAdminContr
         $otherForm = $otherFormDataHandler->getForm();
         $otherForm->handleRequest($request);
 
-        if ($otherForm->isSubmitted() && $otherForm->isValid()) {
+        if ($otherForm->isSubmitted()) {
             $errors = $otherFormDataHandler->save($otherForm->getData());
 
             if (empty($errors)) {
@@ -81,7 +89,7 @@ class DemoConfigurationMultipleFormsController extends FrameworkBundleAdminContr
                 $this->flashErrors($errors);
             }
         }
-        return $this->redirectToRoute('demo_configuration_multiple_forms');
 
+        return $this->redirectToRoute('demo_configuration_multiple_forms');
     }
 }

--- a/demosymfonyform/src/Controller/index.php
+++ b/demosymfonyform/src/Controller/index.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceDataConfiguration.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceDataConfiguration.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceDataConfiguration.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceDataConfiguration.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\DemoSymfonyForm\Form;
+
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Tax\Ecotax\ProductEcotaxResetterInterface;
+
+/**
+ * Handles configuration data for tax options.
+ */
+final class DemoConfigurationChoiceDataConfiguration implements DataConfigurationInterface
+{
+    public const CATEGORY_CHOICE_TREE_TYPE = 'DEMO_SYMFONY_FORM_CATEGORY_CHOICE_TREE_TYPE';
+    public const COUNTRY_CHOICE_TYPE = 'DEMO_SYMFONY_FORM_COUNTRY_CHOICE_TYPE';
+    public const MATERIAL_CHOICE_TABLE_TYPE = 'DEMO_SYMFONY_FORM_MATERIAL_CHOICE_TABLE_TYPE';
+    public const MATERIAL_CHOICE_TREE_TYPE = 'DEMO_SYMFONY_FORM_MATERIAL_CHOICE_TREE_TYPE';
+    public const MATERIAL_CHOICE_MULTIPLE_CHOICES_TABLE = 'DEMO_SYMFONY_FORM_MATERIAL_CHOICE_MULTIPLE_CHOICES_TABLE';
+    public const SHOP_CHOICES_TREE_TYPE = 'DEMO_SYMFONY_FORM_SHOP_CHOICES_TREE_TYPE';
+    public const SWITCH_TYPE = 'DEMO_SYMFONY_FORM_SWITCH_TYPE';
+    public const YES_AND_NO_TYPE = 'DEMO_SYMFONY_FORM_YES_AND_NO_TYPE';
+
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @param ConfigurationInterface $configuration
+     */
+    public function __construct(ConfigurationInterface $configuration) {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration(): array
+    {
+        $return = [];
+
+        if ($categoryChoiceTreeType = $this->configuration->get(static::CATEGORY_CHOICE_TREE_TYPE)) {
+            $return['category_choice_tree_type'] = $categoryChoiceTreeType;
+        }
+        if ($countryChoiceType = $this->configuration->get(static::COUNTRY_CHOICE_TYPE)) {
+            $return['country_choice_type'] = $countryChoiceType;
+        }
+        if ($materialChoiceTableType = $this->configuration->get(static::MATERIAL_CHOICE_TABLE_TYPE)) {
+            $return['material_choice_table_type'] = json_decode($materialChoiceTableType, true);
+        }
+        if ($materialChoiceTreeType = $this->configuration->get(static::MATERIAL_CHOICE_TREE_TYPE)) {
+            $return['material_choice_tree_type'] = $materialChoiceTreeType;
+        }
+        if ($materialChoiceMultipleChoicesTable = $this->configuration->get(static::MATERIAL_CHOICE_MULTIPLE_CHOICES_TABLE)) {
+            $return['material_choice_multiple_choices_table'] = json_decode($materialChoiceMultipleChoicesTable, true);
+        }
+        if ($shopChoicesTreeType = $this->configuration->get(static::SHOP_CHOICES_TREE_TYPE)) {
+            $return['shop_choices_tree_type'] = json_decode($shopChoicesTreeType, true);
+        }
+        if ($switchType = $this->configuration->get(static::SWITCH_TYPE)) {
+            $return['switch_type'] = $switchType;
+        }
+        if ($yesAndNoType = $this->configuration->get(static::YES_AND_NO_TYPE)) {
+            $return['yes_and_no_type'] = $yesAndNoType;
+        }
+
+        return $return;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateConfiguration(array $configuration): array
+    {
+        $this->configuration->set(static::CATEGORY_CHOICE_TREE_TYPE, $configuration['category_choice_tree_type']);
+        $this->configuration->set(static::COUNTRY_CHOICE_TYPE, $configuration['country_choice_type']);
+        $this->configuration->set(static::MATERIAL_CHOICE_TABLE_TYPE, json_encode($configuration['material_choice_table_type']));
+        $this->configuration->set(static::MATERIAL_CHOICE_TREE_TYPE, $configuration['material_choice_tree_type']);
+        $this->configuration->set(static::MATERIAL_CHOICE_MULTIPLE_CHOICES_TABLE, json_encode($configuration['material_choice_multiple_choices_table']));
+        $this->configuration->set(static::SHOP_CHOICES_TREE_TYPE, json_encode($configuration['shop_choices_tree_type']));
+        $this->configuration->set(static::SWITCH_TYPE, $configuration['switch_type']);
+        $this->configuration->set(static::YES_AND_NO_TYPE, $configuration['yes_and_no_type']);
+        return [];
+    }
+
+    /**
+     * Ensure the parameters passed are valid.
+     *
+     * @param array $configuration
+     *
+     * @return bool Returns true if no exception are thrown
+     */
+    public function validateConfiguration(array $configuration): bool
+    {
+        return true;
+    }
+}

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceDataConfiguration.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceDataConfiguration.php
@@ -107,6 +107,7 @@ final class DemoConfigurationChoiceDataConfiguration implements DataConfiguratio
 
     /**
      * Ensure the parameters passed are valid.
+     * This function can be used to validate updateConfiguration(array $configuration) data input.
      *
      * @param array $configuration
      *

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceDataConfiguration.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceDataConfiguration.php
@@ -43,7 +43,6 @@ final class DemoConfigurationChoiceDataConfiguration implements DataConfiguratio
     public const MATERIAL_CHOICE_MULTIPLE_CHOICES_TABLE = 'DEMO_SYMFONY_FORM_MATERIAL_CHOICE_MULTIPLE_CHOICES_TABLE';
     public const SHOP_CHOICES_TREE_TYPE = 'DEMO_SYMFONY_FORM_SHOP_CHOICES_TREE_TYPE';
     public const SWITCH_TYPE = 'DEMO_SYMFONY_FORM_SWITCH_TYPE';
-    public const YES_AND_NO_TYPE = 'DEMO_SYMFONY_FORM_YES_AND_NO_TYPE';
 
     /**
      * @var ConfigurationInterface
@@ -86,9 +85,6 @@ final class DemoConfigurationChoiceDataConfiguration implements DataConfiguratio
         if ($switchType = $this->configuration->get(static::SWITCH_TYPE)) {
             $return['switch_type'] = $switchType;
         }
-        if ($yesAndNoType = $this->configuration->get(static::YES_AND_NO_TYPE)) {
-            $return['yes_and_no_type'] = $yesAndNoType;
-        }
 
         return $return;
     }
@@ -105,7 +101,6 @@ final class DemoConfigurationChoiceDataConfiguration implements DataConfiguratio
         $this->configuration->set(static::MATERIAL_CHOICE_MULTIPLE_CHOICES_TABLE, json_encode($configuration['material_choice_multiple_choices_table']));
         $this->configuration->set(static::SHOP_CHOICES_TREE_TYPE, json_encode($configuration['shop_choices_tree_type']));
         $this->configuration->set(static::SWITCH_TYPE, $configuration['switch_type']);
-        $this->configuration->set(static::YES_AND_NO_TYPE, $configuration['yes_and_no_type']);
 
         return [];
     }

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceDataConfiguration.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceDataConfiguration.php
@@ -30,7 +30,6 @@ namespace PrestaShop\Module\DemoSymfonyForm\Form;
 
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Tax\Ecotax\ProductEcotaxResetterInterface;
 
 /**
  * Handles configuration data for tax options.
@@ -54,7 +53,8 @@ final class DemoConfigurationChoiceDataConfiguration implements DataConfiguratio
     /**
      * @param ConfigurationInterface $configuration
      */
-    public function __construct(ConfigurationInterface $configuration) {
+    public function __construct(ConfigurationInterface $configuration)
+    {
         $this->configuration = $configuration;
     }
 
@@ -106,6 +106,7 @@ final class DemoConfigurationChoiceDataConfiguration implements DataConfiguratio
         $this->configuration->set(static::SHOP_CHOICES_TREE_TYPE, json_encode($configuration['shop_choices_tree_type']));
         $this->configuration->set(static::SWITCH_TYPE, $configuration['switch_type']);
         $this->configuration->set(static::YES_AND_NO_TYPE, $configuration['yes_and_no_type']);
+
         return [];
     }
 

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceFormDataProvider.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceFormDataProvider.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceFormDataProvider.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceFormDataProvider.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\DemoSymfonyForm\Form;
+
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+
+class DemoConfigurationChoiceFormDataProvider implements FormDataProviderInterface
+{
+    /**
+     * @var DataConfigurationInterface
+     */
+    private $demoConfigurationChoiceDataConfiguration;
+
+    /**
+     * @param DataConfigurationInterface $demoConfigurationChoiceDataConfiguration
+     */
+    public function __construct(DataConfigurationInterface $demoConfigurationChoiceDataConfiguration)
+    {
+        $this->demoConfigurationChoiceDataConfiguration = $demoConfigurationChoiceDataConfiguration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(): array
+    {
+        return $this->demoConfigurationChoiceDataConfiguration->getConfiguration();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setData(array $data): array
+    {
+        return $this->demoConfigurationChoiceDataConfiguration->updateConfiguration($data);
+    }
+}
+

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceFormDataProvider.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceFormDataProvider.php
@@ -62,4 +62,3 @@ class DemoConfigurationChoiceFormDataProvider implements FormDataProviderInterfa
         return $this->demoConfigurationChoiceDataConfiguration->updateConfiguration($data);
     }
 }
-

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceType.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\DemoSymfonyForm\Form;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShopBundle\Form\Admin\Type\CategoryChoiceTreeType;
+use PrestaShopBundle\Form\Admin\Type\CountryChoiceType;
+use PrestaShopBundle\Form\Admin\Type\DatePickerType;
+use PrestaShopBundle\Form\Admin\Type\DateRangeType;
+use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
+use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTableType;
+use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
+use PrestaShopBundle\Form\Admin\Type\Material\MaterialMultipleChoiceTableType;
+use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class DemoConfigurationChoiceType extends TranslatorAwareType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $disabledCategories = [5];
+
+        $builder
+            ->add('category_choice_tree_type', CategoryChoiceTreeType::class, [
+                'label' => $this->trans('Category choice type', 'Modules.DemoSymfonyForm.Admin'),
+                'disabled_values' => $disabledCategories,
+            ])
+            ->add('country_choice_type', CountryChoiceType::class, [
+                'label' => $this->trans('Country choice type', 'Modules.DemoSymfonyForm.Admin'),
+                'required' => true,
+                'with_dni_attr' => true,
+                'with_postcode_attr' => true,
+                ]
+            )
+            ->add('material_choice_table_type', MaterialChoiceTableType::class, [
+                    'label' => $this->trans('Material choice table type', 'Modules.DemoSymfonyForm.Admin'),
+                    'choices' => [
+                        $this->trans('Choice 1', 'Modules.DemoSymfonyForm.Admin') => '1',
+                        $this->trans('Choice 2', 'Modules.DemoSymfonyForm.Admin') => '2',
+                    ]
+                ]
+            )
+            ->add('material_choice_tree_type', MaterialChoiceTreeType::class, [
+                    'label' => $this->trans('Material choice tree type', 'Modules.DemoSymfonyForm.Admin'),
+                    'choice_value' => 'id_choice',
+                    'choices_tree' => [
+                        '1' => [
+                            'id_choice' => 1,
+                            'name' => $this->trans('Choice 1', 'Modules.DemoSymfonyForm.Admin')
+                        ],
+                        '2' => [
+                            'id_choice' => 2,
+                            'name' => $this->trans('Choice 2', 'Modules.DemoSymfonyForm.Admin'),
+                            'children' => [
+                                '3' => [
+                                    'id_choice' => 3,
+                                    'name' => $this->trans('Choice 3', 'Modules.DemoSymfonyForm.Admin')
+                                ],
+                                '4' => [
+                                    'id_choice' => 4,
+                                    'name' => $this->trans('Choice 4', 'Modules.DemoSymfonyForm.Admin')
+                                ],
+                            ]
+                        ],
+                    ]
+                ]
+            )
+            ->add('material_choice_multiple_choices_table', MaterialMultipleChoiceTableType::class, [
+                    'label' => $this->trans('Material choice multiple choices table type', 'Modules.DemoSymfonyForm.Admin'),
+                    'choices' => [
+                        $this->trans('Vertical choice 1', 'Modules.DemoSymfonyForm.Admin') => '1',
+                        $this->trans('Vertical choice 2', 'Modules.DemoSymfonyForm.Admin') => '2',
+                        $this->trans('Vertical choice 3', 'Modules.DemoSymfonyForm.Admin') => '3',
+                    ],
+                    'multiple_choices' => [
+                        [
+                            'name' => 'choice_1',
+                            'label' => $this->trans('Horizontal choice 1', 'Modules.DemoSymfonyForm.Admin'),
+                            'multiple' => true,
+                            /** You need choices array for the second time to be able to choose which horizontal choices are available for this vertical choice  */
+                            'choices' => [
+                                $this->trans('Vertical choice 1', 'Modules.DemoSymfonyForm.Admin') => '1',
+                                $this->trans('Vertical choice 2', 'Modules.DemoSymfonyForm.Admin') => '2',
+                            ],
+                        ],
+                        [
+                            'name' => 'choice_2',
+                            'label' => $this->trans('Horizontal choice 2', 'Modules.DemoSymfonyForm.Admin'),
+                            'multiple' => true,
+                            'choices' => [
+                                $this->trans('Vertical choice 1', 'Modules.DemoSymfonyForm.Admin') => '1',
+                                $this->trans('Vertical choice 2', 'Modules.DemoSymfonyForm.Admin') => '2',
+                                $this->trans('Vertical choice 3', 'Modules.DemoSymfonyForm.Admin') => '3',
+                            ],
+                        ],
+                    ],
+                ]
+            )
+            ->add('shop_choices_tree_type', ShopChoiceTreeType::class, [
+                    'label' => $this->trans('Material choice tree type', 'Modules.DemoSymfonyForm.Admin'),
+                ]
+            )
+            ->add('switch_type', SwitchType::class, [
+                    'label' => $this->trans('Switch type', 'Modules.DemoSymfonyForm.Admin'),
+                ]
+            )
+            ->add('yes_and_no_type', YesAndNoChoiceType::class, [
+                    'label' => $this->trans('Yes and no type', 'Modules.DemoSymfonyForm.Admin'),
+                ]
+            );
+    }
+}

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceType.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceType.php
@@ -36,7 +36,6 @@ use PrestaShopBundle\Form\Admin\Type\Material\MaterialMultipleChoiceTableType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class DemoConfigurationChoiceType extends TranslatorAwareType
@@ -151,13 +150,6 @@ class DemoConfigurationChoiceType extends TranslatorAwareType
                 SwitchType::class,
                 [
                     'label' => $this->trans('Switch type', 'Modules.DemoSymfonyForm.Admin'),
-                ]
-            )
-            ->add(
-                'yes_and_no_type',
-                YesAndNoChoiceType::class,
-                [
-                    'label' => $this->trans('Yes and no type', 'Modules.DemoSymfonyForm.Admin'),
                 ]
             );
     }

--- a/demosymfonyform/src/Form/DemoConfigurationChoiceType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationChoiceType.php
@@ -28,24 +28,16 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\DemoSymfonyForm\Form;
 
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShopBundle\Form\Admin\Type\CategoryChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\CountryChoiceType;
-use PrestaShopBundle\Form\Admin\Type\DatePickerType;
-use PrestaShopBundle\Form\Admin\Type\DateRangeType;
-use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTableType;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialMultipleChoiceTableType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints\Length;
-use Symfony\Component\Validator\Constraints\NotBlank;
 
 class DemoConfigurationChoiceType extends TranslatorAwareType
 {
@@ -57,32 +49,45 @@ class DemoConfigurationChoiceType extends TranslatorAwareType
         $disabledCategories = [5];
 
         $builder
-            ->add('category_choice_tree_type', CategoryChoiceTreeType::class, [
-                'label' => $this->trans('Category choice type', 'Modules.DemoSymfonyForm.Admin'),
-                'disabled_values' => $disabledCategories,
-            ])
-            ->add('country_choice_type', CountryChoiceType::class, [
-                'label' => $this->trans('Country choice type', 'Modules.DemoSymfonyForm.Admin'),
-                'required' => true,
-                'with_dni_attr' => true,
-                'with_postcode_attr' => true,
+            ->add(
+                'category_choice_tree_type',
+                CategoryChoiceTreeType::class,
+                [
+                    'label' => $this->trans('Category choice type', 'Modules.DemoSymfonyForm.Admin'),
+                    'disabled_values' => $disabledCategories,
                 ]
             )
-            ->add('material_choice_table_type', MaterialChoiceTableType::class, [
+            ->add(
+                'country_choice_type',
+                CountryChoiceType::class,
+                [
+                    'label' => $this->trans('Country choice type', 'Modules.DemoSymfonyForm.Admin'),
+                    'required' => true,
+                    'with_dni_attr' => true,
+                    'with_postcode_attr' => true,
+                ]
+            )
+            ->add(
+                'material_choice_table_type',
+                MaterialChoiceTableType::class,
+                [
                     'label' => $this->trans('Material choice table type', 'Modules.DemoSymfonyForm.Admin'),
                     'choices' => [
                         $this->trans('Choice 1', 'Modules.DemoSymfonyForm.Admin') => '1',
                         $this->trans('Choice 2', 'Modules.DemoSymfonyForm.Admin') => '2',
-                    ]
+                    ],
                 ]
             )
-            ->add('material_choice_tree_type', MaterialChoiceTreeType::class, [
+            ->add(
+                'material_choice_tree_type',
+                MaterialChoiceTreeType::class,
+                [
                     'label' => $this->trans('Material choice tree type', 'Modules.DemoSymfonyForm.Admin'),
                     'choice_value' => 'id_choice',
                     'choices_tree' => [
                         '1' => [
                             'id_choice' => 1,
-                            'name' => $this->trans('Choice 1', 'Modules.DemoSymfonyForm.Admin')
+                            'name' => $this->trans('Choice 1', 'Modules.DemoSymfonyForm.Admin'),
                         ],
                         '2' => [
                             'id_choice' => 2,
@@ -90,18 +95,21 @@ class DemoConfigurationChoiceType extends TranslatorAwareType
                             'children' => [
                                 '3' => [
                                     'id_choice' => 3,
-                                    'name' => $this->trans('Choice 3', 'Modules.DemoSymfonyForm.Admin')
+                                    'name' => $this->trans('Choice 3', 'Modules.DemoSymfonyForm.Admin'),
                                 ],
                                 '4' => [
                                     'id_choice' => 4,
-                                    'name' => $this->trans('Choice 4', 'Modules.DemoSymfonyForm.Admin')
+                                    'name' => $this->trans('Choice 4', 'Modules.DemoSymfonyForm.Admin'),
                                 ],
-                            ]
+                            ],
                         ],
-                    ]
+                    ],
                 ]
             )
-            ->add('material_choice_multiple_choices_table', MaterialMultipleChoiceTableType::class, [
+            ->add(
+                'material_choice_multiple_choices_table',
+                MaterialMultipleChoiceTableType::class,
+                [
                     'label' => $this->trans('Material choice multiple choices table type', 'Modules.DemoSymfonyForm.Admin'),
                     'choices' => [
                         $this->trans('Vertical choice 1', 'Modules.DemoSymfonyForm.Admin') => '1',
@@ -113,7 +121,7 @@ class DemoConfigurationChoiceType extends TranslatorAwareType
                             'name' => 'choice_1',
                             'label' => $this->trans('Horizontal choice 1', 'Modules.DemoSymfonyForm.Admin'),
                             'multiple' => true,
-                            /** You need choices array for the second time to be able to choose which horizontal choices are available for this vertical choice  */
+                            /* You need choices array for the second time to be able to choose which horizontal choices are available for this vertical choice  */
                             'choices' => [
                                 $this->trans('Vertical choice 1', 'Modules.DemoSymfonyForm.Admin') => '1',
                                 $this->trans('Vertical choice 2', 'Modules.DemoSymfonyForm.Admin') => '2',
@@ -132,15 +140,23 @@ class DemoConfigurationChoiceType extends TranslatorAwareType
                     ],
                 ]
             )
-            ->add('shop_choices_tree_type', ShopChoiceTreeType::class, [
+            ->add('shop_choices_tree_type',
+                ShopChoiceTreeType::class,
+                [
                     'label' => $this->trans('Material choice tree type', 'Modules.DemoSymfonyForm.Admin'),
                 ]
             )
-            ->add('switch_type', SwitchType::class, [
+            ->add(
+                'switch_type',
+                SwitchType::class,
+                [
                     'label' => $this->trans('Switch type', 'Modules.DemoSymfonyForm.Admin'),
                 ]
             )
-            ->add('yes_and_no_type', YesAndNoChoiceType::class, [
+            ->add(
+                'yes_and_no_type',
+                YesAndNoChoiceType::class,
+                [
                     'label' => $this->trans('Yes and no type', 'Modules.DemoSymfonyForm.Admin'),
                 ]
             );

--- a/demosymfonyform/src/Form/DemoConfigurationOtherDataConfiguration.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherDataConfiguration.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\DemoSymfonyForm\Form;
+
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Tax\Ecotax\ProductEcotaxResetterInterface;
+
+/**
+ * Handles configuration data for tax options.
+ */
+final class DemoConfigurationOtherDataConfiguration implements DataConfigurationInterface
+{
+    public const CHANGE_PASSWORD_TYPE = 'DEMO_SYMFONY_FORM_CHANGE_PASSWORD_TYPE';
+    public const MONEY_WITH_SUFFIX_TYPE = 'DEMO_SYMFONY_FORM_MONEY_WITH_SUFFIX_TYPE';
+    public const DATE_PICKER_TYPE = 'DEMO_SYMFONY_FORM_DATE_PICKER_TYPE';
+    public const DATE_RANGE_TYPE = 'DEMO_SYMFONY_FORM_DATE_RANGE_TYPE';
+    public const INTEGER_MIN_MAX_FILTER_TYPE = 'DEMO_SYMFONY_FORM_INTEGER_MIN_MAX_FILTER_TYPE';
+    public const NUMBER_MIN_MAX_FILTER_TYPE = 'DEMO_SYMFONY_FORM_NUMBER_MIN_MAX_FILTER_TYPE';
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @param ConfigurationInterface $configuration
+     */
+    public function __construct(ConfigurationInterface $configuration) {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration(): array
+    {
+        $return = [];
+        if ($changePasswordType = $this->configuration->get(static::CHANGE_PASSWORD_TYPE)) {
+            $return['change_password_type'] = $changePasswordType;
+        }
+        if ($moneyWithSuffixType = $this->configuration->get(static::MONEY_WITH_SUFFIX_TYPE)) {
+            $return['money_with_suffix_type'] = $moneyWithSuffixType;
+        }
+        if ($datePickerType = $this->configuration->get(static::DATE_PICKER_TYPE)) {
+            $return['date_picker_type'] = $datePickerType;
+        }
+        if ($dateRangeType = $this->configuration->get(static::DATE_RANGE_TYPE)) {
+            $return['date_range_type'] = json_decode($dateRangeType, true);
+        }
+        if ($integerMinMaxFilterType = $this->configuration->get(static::INTEGER_MIN_MAX_FILTER_TYPE)) {
+            $return['integer_min_max_filter_type'] = json_decode($integerMinMaxFilterType, true);
+        }
+        if ($numberMinMaxFilterType = $this->configuration->get(static::NUMBER_MIN_MAX_FILTER_TYPE)) {
+            $return['number_min_max_filter_type'] = json_decode($numberMinMaxFilterType, true);
+        }
+        return $return;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateConfiguration(array $configuration): array
+    {
+        $this->configuration->set(static::CHANGE_PASSWORD_TYPE, $configuration['change_password_type']);
+        $this->configuration->set(static::MONEY_WITH_SUFFIX_TYPE, $configuration['money_with_suffix_type']);
+        $this->configuration->set(static::DATE_PICKER_TYPE, $configuration['date_picker_type']);
+        $this->configuration->set(static::DATE_RANGE_TYPE, json_encode($configuration['date_range_type']));
+        $this->configuration->set(static::INTEGER_MIN_MAX_FILTER_TYPE, json_encode($configuration['integer_min_max_filter_type']));
+        $this->configuration->set(static::NUMBER_MIN_MAX_FILTER_TYPE, json_encode($configuration['number_min_max_filter_type']));
+        return [];
+    }
+
+    /**
+     * Ensure the parameters passed are valid.
+     *
+     * @param array $configuration
+     *
+     * @return bool Returns true if no exception are thrown
+     */
+    public function validateConfiguration(array $configuration): bool
+    {
+        return true;
+    }
+}

--- a/demosymfonyform/src/Form/DemoConfigurationOtherDataConfiguration.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherDataConfiguration.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);

--- a/demosymfonyform/src/Form/DemoConfigurationOtherDataConfiguration.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherDataConfiguration.php
@@ -30,7 +30,6 @@ namespace PrestaShop\Module\DemoSymfonyForm\Form;
 
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Tax\Ecotax\ProductEcotaxResetterInterface;
 
 /**
  * Handles configuration data for tax options.
@@ -51,7 +50,8 @@ final class DemoConfigurationOtherDataConfiguration implements DataConfiguration
     /**
      * @param ConfigurationInterface $configuration
      */
-    public function __construct(ConfigurationInterface $configuration) {
+    public function __construct(ConfigurationInterface $configuration)
+    {
         $this->configuration = $configuration;
     }
 
@@ -79,6 +79,7 @@ final class DemoConfigurationOtherDataConfiguration implements DataConfiguration
         if ($numberMinMaxFilterType = $this->configuration->get(static::NUMBER_MIN_MAX_FILTER_TYPE)) {
             $return['number_min_max_filter_type'] = json_decode($numberMinMaxFilterType, true);
         }
+
         return $return;
     }
 
@@ -93,6 +94,7 @@ final class DemoConfigurationOtherDataConfiguration implements DataConfiguration
         $this->configuration->set(static::DATE_RANGE_TYPE, json_encode($configuration['date_range_type']));
         $this->configuration->set(static::INTEGER_MIN_MAX_FILTER_TYPE, json_encode($configuration['integer_min_max_filter_type']));
         $this->configuration->set(static::NUMBER_MIN_MAX_FILTER_TYPE, json_encode($configuration['number_min_max_filter_type']));
+
         return [];
     }
 

--- a/demosymfonyform/src/Form/DemoConfigurationOtherDataConfiguration.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherDataConfiguration.php
@@ -36,7 +36,6 @@ use PrestaShop\PrestaShop\Core\ConfigurationInterface;
  */
 final class DemoConfigurationOtherDataConfiguration implements DataConfigurationInterface
 {
-    public const CHANGE_PASSWORD_TYPE = 'DEMO_SYMFONY_FORM_CHANGE_PASSWORD_TYPE';
     public const MONEY_WITH_SUFFIX_TYPE = 'DEMO_SYMFONY_FORM_MONEY_WITH_SUFFIX_TYPE';
     public const DATE_PICKER_TYPE = 'DEMO_SYMFONY_FORM_DATE_PICKER_TYPE';
     public const DATE_RANGE_TYPE = 'DEMO_SYMFONY_FORM_DATE_RANGE_TYPE';
@@ -61,9 +60,7 @@ final class DemoConfigurationOtherDataConfiguration implements DataConfiguration
     public function getConfiguration(): array
     {
         $return = [];
-        if ($changePasswordType = $this->configuration->get(static::CHANGE_PASSWORD_TYPE)) {
-            $return['change_password_type'] = $changePasswordType;
-        }
+
         if ($moneyWithSuffixType = $this->configuration->get(static::MONEY_WITH_SUFFIX_TYPE)) {
             $return['money_with_suffix_type'] = $moneyWithSuffixType;
         }
@@ -88,7 +85,6 @@ final class DemoConfigurationOtherDataConfiguration implements DataConfiguration
      */
     public function updateConfiguration(array $configuration): array
     {
-        $this->configuration->set(static::CHANGE_PASSWORD_TYPE, $configuration['change_password_type']);
         $this->configuration->set(static::MONEY_WITH_SUFFIX_TYPE, $configuration['money_with_suffix_type']);
         $this->configuration->set(static::DATE_PICKER_TYPE, $configuration['date_picker_type']);
         $this->configuration->set(static::DATE_RANGE_TYPE, json_encode($configuration['date_range_type']));

--- a/demosymfonyform/src/Form/DemoConfigurationOtherFormDataProvider.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherFormDataProvider.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\DemoSymfonyForm\Form;
+
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+
+class DemoConfigurationOtherFormDataProvider implements FormDataProviderInterface
+{
+    /**
+     * @var DataConfigurationInterface
+     */
+    private $demoConfigurationDataConfiguration;
+
+    /**
+     * @param DataConfigurationInterface $demoConfigurationDataConfiguration
+     */
+    public function __construct(DataConfigurationInterface $demoConfigurationDataConfiguration)
+    {
+        $this->demoConfigurationDataConfiguration = $demoConfigurationDataConfiguration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(): array
+    {
+        return $this->demoConfigurationDataConfiguration->getConfiguration();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setData(array $data): array
+    {
+        return $this->demoConfigurationDataConfiguration->updateConfiguration($data);
+    }
+}
+

--- a/demosymfonyform/src/Form/DemoConfigurationOtherFormDataProvider.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherFormDataProvider.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);

--- a/demosymfonyform/src/Form/DemoConfigurationOtherFormDataProvider.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherFormDataProvider.php
@@ -62,4 +62,3 @@ class DemoConfigurationOtherFormDataProvider implements FormDataProviderInterfac
         return $this->demoConfigurationDataConfiguration->updateConfiguration($data);
     }
 }
-

--- a/demosymfonyform/src/Form/DemoConfigurationOtherType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherType.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\DemoSymfonyForm\Form;
+
+use PrestaShopBundle\Form\Admin\Type\ChangePasswordType;
+use PrestaShopBundle\Form\Admin\Type\DatePickerType;
+use PrestaShopBundle\Form\Admin\Type\DateRangeType;
+use PrestaShopBundle\Form\Admin\Type\IntegerMinMaxFilterType;
+use PrestaShopBundle\Form\Admin\Type\MoneyWithSuffixType;
+use PrestaShopBundle\Form\Admin\Type\NumberMinMaxFilterType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class DemoConfigurationOtherType extends TranslatorAwareType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('change_password_type', ChangePasswordType::class, [
+                    'label' => $this->trans('Change password type', 'Modules.DemoSymfonyForm.Admin'),
+                ]
+            )
+            ->add('money_with_suffix_type', MoneyWithSuffixType::class, [
+                    'label' => $this->trans('Money with suffix', 'Modules.DemoSymfonyForm.Admin'),
+                    'help' => $this->trans(
+                        'https://devdocs.prestashop.com/1.7/development/components/form/types-reference/money-with-suffix/',
+                        'Modules.DemoSymfonyForm.Admin'
+                    )
+                ]
+            )
+            ->add('date_picker_type', DatePickerType::class, [
+                    'label' => $this->trans('Date picker type', 'Modules.DemoSymfonyForm.Admin'),
+                ]
+            )
+            ->add('date_range_type', DateRangeType::class, [
+                    'label' => $this->trans('Date range type', 'Modules.DemoSymfonyForm.Admin'),
+                ]
+            )
+            ->add('integer_min_max_filter_type', IntegerMinMaxFilterType::class, [
+                    'label' => $this->trans('Integer min max filter type', 'Modules.DemoSymfonyForm.Admin'),
+                    'min_field_options' => [
+                        'attr' => [
+                            'placeholder' => $this->trans('Min','Admin.Global'),
+                            'min' => 0,
+                            'step' => 1,
+                        ],
+                    ],
+                    'max_field_options' => [
+                        'attr' => [
+                            'placeholder' => $this->trans('Max','Admin.Global'),
+                            'min' => 100,
+                            'step' => 3,
+                        ],
+                    ]
+
+                ]
+            )
+            ->add('number_min_max_filter_type', NumberMinMaxFilterType::class, [
+                    'label' => $this->trans('Number min max filter type', 'Modules.DemoSymfonyForm.Admin'),
+                    'min_field_options' => [
+                        'attr' => [
+                            'placeholder'=> $this->trans('Min', 'Admin.Global')
+                        ]
+                    ],
+                    'max_field_options' => [
+                        'attr' => [
+                            'placeholder'=> $this->trans('Max', 'Admin.Global')
+                        ]
+                    ],
+                ]
+            );
+    }
+}

--- a/demosymfonyform/src/Form/DemoConfigurationOtherType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherType.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);

--- a/demosymfonyform/src/Form/DemoConfigurationOtherType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherType.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\DemoSymfonyForm\Form;
 
-use PrestaShopBundle\Form\Admin\Type\ChangePasswordType;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\IntegerMinMaxFilterType;

--- a/demosymfonyform/src/Form/DemoConfigurationOtherType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherType.php
@@ -46,13 +46,6 @@ class DemoConfigurationOtherType extends TranslatorAwareType
     {
         $builder
             ->add(
-                'change_password_type',
-                ChangePasswordType::class,
-                [
-                    'label' => $this->trans('Change password type', 'Modules.DemoSymfonyForm.Admin'),
-                ]
-            )
-            ->add(
                 'money_with_suffix_type',
                 MoneyWithSuffixType::class,
                 [

--- a/demosymfonyform/src/Form/DemoConfigurationOtherType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationOtherType.php
@@ -45,56 +45,69 @@ class DemoConfigurationOtherType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('change_password_type', ChangePasswordType::class, [
+            ->add(
+                'change_password_type',
+                ChangePasswordType::class,
+                [
                     'label' => $this->trans('Change password type', 'Modules.DemoSymfonyForm.Admin'),
                 ]
             )
-            ->add('money_with_suffix_type', MoneyWithSuffixType::class, [
+            ->add(
+                'money_with_suffix_type',
+                MoneyWithSuffixType::class,
+                [
                     'label' => $this->trans('Money with suffix', 'Modules.DemoSymfonyForm.Admin'),
-                    'help' => $this->trans(
-                        'https://devdocs.prestashop.com/1.7/development/components/form/types-reference/money-with-suffix/',
-                        'Modules.DemoSymfonyForm.Admin'
-                    )
                 ]
             )
-            ->add('date_picker_type', DatePickerType::class, [
+            ->add(
+                'date_picker_type',
+                DatePickerType::class,
+                [
                     'label' => $this->trans('Date picker type', 'Modules.DemoSymfonyForm.Admin'),
                 ]
             )
-            ->add('date_range_type', DateRangeType::class, [
+            ->add(
+                'date_range_type',
+                DateRangeType::class,
+                [
                     'label' => $this->trans('Date range type', 'Modules.DemoSymfonyForm.Admin'),
                 ]
             )
-            ->add('integer_min_max_filter_type', IntegerMinMaxFilterType::class, [
+            ->add(
+                'integer_min_max_filter_type',
+                IntegerMinMaxFilterType::class,
+                [
                     'label' => $this->trans('Integer min max filter type', 'Modules.DemoSymfonyForm.Admin'),
                     'min_field_options' => [
                         'attr' => [
-                            'placeholder' => $this->trans('Min','Admin.Global'),
+                            'placeholder' => $this->trans('Min', 'Admin.Global'),
                             'min' => 0,
                             'step' => 1,
                         ],
                     ],
                     'max_field_options' => [
                         'attr' => [
-                            'placeholder' => $this->trans('Max','Admin.Global'),
+                            'placeholder' => $this->trans('Max', 'Admin.Global'),
                             'min' => 100,
                             'step' => 3,
                         ],
-                    ]
-
+                    ],
                 ]
             )
-            ->add('number_min_max_filter_type', NumberMinMaxFilterType::class, [
+            ->add(
+                'number_min_max_filter_type',
+                NumberMinMaxFilterType::class,
+                [
                     'label' => $this->trans('Number min max filter type', 'Modules.DemoSymfonyForm.Admin'),
                     'min_field_options' => [
                         'attr' => [
-                            'placeholder'=> $this->trans('Min', 'Admin.Global')
-                        ]
+                            'placeholder' => $this->trans('Min', 'Admin.Global'),
+                        ],
                     ],
                     'max_field_options' => [
                         'attr' => [
-                            'placeholder'=> $this->trans('Max', 'Admin.Global')
-                        ]
+                            'placeholder' => $this->trans('Max', 'Admin.Global'),
+                        ],
                     ],
                 ]
             );

--- a/demosymfonyform/src/Form/DemoConfigurationTextDataConfiguration.php
+++ b/demosymfonyform/src/Form/DemoConfigurationTextDataConfiguration.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);

--- a/demosymfonyform/src/Form/DemoConfigurationTextFormDataProvider.php
+++ b/demosymfonyform/src/Form/DemoConfigurationTextFormDataProvider.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);

--- a/demosymfonyform/src/Form/DemoConfigurationTextType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationTextType.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 declare(strict_types=1);

--- a/demosymfonyform/src/Form/index.php
+++ b/demosymfonyform/src/Form/index.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

--- a/demosymfonyform/views/index.php
+++ b/demosymfonyform/views/index.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

--- a/demosymfonyform/views/js/form.js
+++ b/demosymfonyform/views/js/form.js
@@ -4,23 +4,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 $(document).ready(function () {

--- a/demosymfonyform/views/js/index.php
+++ b/demosymfonyform/views/js/index.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

--- a/demosymfonyform/views/js/multipleForms.js
+++ b/demosymfonyform/views/js/multipleForms.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+$(document).ready(function () {
+    window.prestashop.component.initComponents(
+      [
+        'TranslatableField',
+        'TinyMCEEditor',
+        'TranslatableInput',
+        'GeneratableInput',
+        'TextWithLengthCounter',
+        'ChoiceTable',
+        'MultipleChoiceTable'
+      ],
+    );
+
+    window.prestashop.instance.generatableInput.attachOn('.js-generator-btn');
+    new window.prestashop.component.ChoiceTree('#form_category_choice_tree_type');
+    new window.prestashop.component.ChoiceTree('#form_material_choice_tree_type');
+    new window.prestashop.component.ChoiceTree('#form_shop_choices_tree_type').enableAutoCheckChildren();
+});

--- a/demosymfonyform/views/js/multipleForms.js
+++ b/demosymfonyform/views/js/multipleForms.js
@@ -35,3 +35,4 @@ $(document).ready(function () {
     new window.prestashop.component.ChoiceTree('#form_material_choice_tree_type');
     new window.prestashop.component.ChoiceTree('#form_shop_choices_tree_type').enableAutoCheckChildren();
 });
+

--- a/demosymfonyform/views/js/multipleForms.js
+++ b/demosymfonyform/views/js/multipleForms.js
@@ -4,23 +4,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
 $(document).ready(function () {

--- a/demosymfonyform/views/js/multipleForms.js
+++ b/demosymfonyform/views/js/multipleForms.js
@@ -26,17 +26,11 @@
 $(document).ready(function () {
     window.prestashop.component.initComponents(
       [
-        'TranslatableField',
-        'TinyMCEEditor',
-        'TranslatableInput',
-        'GeneratableInput',
-        'TextWithLengthCounter',
         'ChoiceTable',
         'MultipleChoiceTable'
       ],
     );
 
-    window.prestashop.instance.generatableInput.attachOn('.js-generator-btn');
     new window.prestashop.component.ChoiceTree('#form_category_choice_tree_type');
     new window.prestashop.component.ChoiceTree('#form_material_choice_tree_type');
     new window.prestashop.component.ChoiceTree('#form_shop_choices_tree_type').enableAutoCheckChildren();

--- a/demosymfonyform/views/templates/admin/form.html.twig
+++ b/demosymfonyform/views/templates/admin/form.html.twig
@@ -16,6 +16,13 @@
   * @copyright Since 2007 PrestaShop SA and Contributors
   * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
   *#}
+{% set layoutHeaderToolbarBtn = {
+  'add' : {
+    'href': path('demo_configuration_multiple_forms'),
+    'desc': 'Switch to Multiple Forms',
+    'icon': 'add_to_photos'
+  }
+} %}
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 

--- a/demosymfonyform/views/templates/admin/form.html.twig
+++ b/demosymfonyform/views/templates/admin/form.html.twig
@@ -1,27 +1,21 @@
 {#**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+  * Copyright since 2007 PrestaShop SA and Contributors
+  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+  * that is bundled with this package in the file LICENSE.md.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/AFL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * @author    PrestaShop SA <contact@prestashop.com>
+  * @copyright Since 2007 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+  *#}
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 

--- a/demosymfonyform/views/templates/admin/index.php
+++ b/demosymfonyform/views/templates/admin/index.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

--- a/demosymfonyform/views/templates/admin/multipleForms.html.twig
+++ b/demosymfonyform/views/templates/admin/multipleForms.html.twig
@@ -16,6 +16,13 @@
   * @copyright Since 2007 PrestaShop SA and Contributors
   * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
   *#}
+{% set layoutHeaderToolbarBtn = {
+  'add' : {
+    'href': path('demo_configuration_form'),
+    'desc': 'Switch to Simple Forms',
+    'icon': 'add_to_photos'
+  }
+} %}
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% form_theme demoConfigurationChoiceForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}

--- a/demosymfonyform/views/templates/admin/multipleForms.html.twig
+++ b/demosymfonyform/views/templates/admin/multipleForms.html.twig
@@ -1,27 +1,21 @@
 {#**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+  * Copyright since 2007 PrestaShop SA and Contributors
+  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+  * that is bundled with this package in the file LICENSE.md.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/AFL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * @author    PrestaShop SA <contact@prestashop.com>
+  * @copyright Since 2007 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+  *#}
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% form_theme demoConfigurationChoiceForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}

--- a/demosymfonyform/views/templates/admin/multipleForms.html.twig
+++ b/demosymfonyform/views/templates/admin/multipleForms.html.twig
@@ -1,0 +1,76 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+{% form_theme demoConfigurationChoiceForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
+{% form_theme demoConfigurationOtherForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
+
+
+{% block content %}
+  {{ form_start(demoConfigurationChoiceForm, {attr : {class: 'form'}, action: path('demo_configuration_choices_form_save') }) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">settings</i> {{ 'Choice form types'|trans({}, 'Modules.DemoSymfonyForm.Admin') }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+          {{ form_widget(demoConfigurationChoiceForm) }}
+      </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary float-right" id="demo-configuration-choices-form-save-button">
+          {{ 'Save'|trans({}, 'Admin.Actions') }}
+        </button>
+      </div>
+    </div>
+  </div>
+  {{ form_end(demoConfigurationChoiceForm) }}
+
+  {{ form_start(demoConfigurationOtherForm, {attr : {class: 'form'}, action: path('demo_configuration_other_form_save') }) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">settings</i> {{ 'Other form types'|trans({}, 'Modules.DemoSymfonyForm.Admin') }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ form_widget(demoConfigurationOtherForm) }}
+      </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary float-right" id="save-button">
+          {{ 'Save'|trans({}, 'Admin.Actions') }}
+        </button>
+      </div>
+    </div>
+  </div>
+  {{ form_end(demoConfigurationOtherForm) }}
+{% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+  <script src="{{ asset('../modules/demosymfonyform/views/js/multipleForms.js') }}"></script>
+{% endblock %}

--- a/demosymfonyform/views/templates/admin/multipleForms.html.twig
+++ b/demosymfonyform/views/templates/admin/multipleForms.html.twig
@@ -27,8 +27,8 @@
 {% form_theme demoConfigurationChoiceForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 {% form_theme demoConfigurationOtherForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
-
 {% block content %}
+  {#  If you want form to use other url for saving you can set it here as path parameter(has to be route registered in routes.yml#}
   {{ form_start(demoConfigurationChoiceForm, {attr : {class: 'form'}, action: path('demo_configuration_choices_form_save') }) }}
   <div class="card">
     <h3 class="card-header">

--- a/demosymfonyform/views/templates/index.php
+++ b/demosymfonyform/views/templates/index.php
@@ -5,23 +5,17 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adding new controller and other and choice types to example form. Using another controller to show how to work with multiple forms in one page.<br><br>YesAndNo Type not added ⚠️  because for some reason it won't show correct value when you retrieve it from database and is meant more for grid.<br><br>Not adding ChangePassword at this point because it's specific to employee form.
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | All forms must work and save correctly

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
