### PR TITLE
set demomultistoreform module's max PS version to current version

### DIFF
--- a/democonsolecommand/democonsolecommand.php
+++ b/democonsolecommand/democonsolecommand.php
@@ -15,7 +15,7 @@ class DemoConsoleCommand extends Module
         $this->name = 'democonsolecommand';
         $this->author = 'PrestaShop';
         $this->version = '1.0.0';
-        $this->ps_versions_compliancy = ['min' => '1.7.7.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.7.0', 'max' => '8.99.99'];
 
         parent::__construct();
 

--- a/democontrollertabs/democontrollertabs.php
+++ b/democontrollertabs/democontrollertabs.php
@@ -36,7 +36,7 @@ class democontrollertabs extends Module
         $this->name = 'democontrollertabs';
         $this->author = 'PrestaShop';
         $this->version = '1.0.0';
-        $this->ps_versions_compliancy = ['min' => '1.7.7', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.7', 'max' => '8.99.99'];
 
         parent::__construct();
 

--- a/demodoctrine/demodoctrine.php
+++ b/demodoctrine/demodoctrine.php
@@ -26,7 +26,7 @@ class DemoDoctrine extends Module
         $this->name = 'demodoctrine';
         $this->author = 'PrestaShop';
         $this->version = '1.0.0';
-        $this->ps_versions_compliancy = ['min' => '1.7.7', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.7', 'max' => '8.99.99'];
 
         parent::__construct();
 

--- a/demoextendgrid/demoextendgrid.php
+++ b/demoextendgrid/demoextendgrid.php
@@ -39,7 +39,7 @@ class DemoExtendGrid extends Module
         $this->name = 'demoextendgrid';
         $this->author = 'PrestaShop';
         $this->version = '1.1.0';
-        $this->ps_versions_compliancy = ['min' => '1.7.8', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.8', 'max' => '8.99.99'];
 
         parent::__construct();
 

--- a/demoextendsymfonyform1/demoextendsymfonyform1.php
+++ b/demoextendsymfonyform1/demoextendsymfonyform1.php
@@ -51,7 +51,7 @@ class DemoExtendSymfonyForm1 extends Module
 
         $this->ps_versions_compliancy = [
             'min' => '1.7.6.0',
-            'max' => _PS_VERSION_,
+            'max' => '8.99.99',
         ];
     }
 

--- a/demoextendsymfonyform2/demoextendsymfonyform2.php
+++ b/demoextendsymfonyform2/demoextendsymfonyform2.php
@@ -37,7 +37,7 @@ class DemoExtendSymfonyForm2 extends Module
         $this->name = 'demoextendsymfonyform2';
         $this->author = 'PrestaShop';
         $this->version = '1.0.0';
-        $this->ps_versions_compliancy = ['min' => '1.7.7.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.7.0', 'max' => '8.99.99'];
 
         parent::__construct();
 

--- a/demoextendsymfonyform3/demoextendsymfonyform3.php
+++ b/demoextendsymfonyform3/demoextendsymfonyform3.php
@@ -56,7 +56,7 @@ class DemoExtendSymfonyForm3 extends Module
 
         $this->ps_versions_compliancy = [
             'min' => '1.7.6.0',
-            'max' => _PS_VERSION_,
+            'max' => '8.99.99',
         ];
     }
 

--- a/demojsrouting/demojsrouting.php
+++ b/demojsrouting/demojsrouting.php
@@ -44,7 +44,7 @@ class DemoJsRouting extends Module
         $this->name = 'demojsrouting';
         $this->author = 'PrestaShop';
         $this->version = '1.0.0';
-        $this->ps_versions_compliancy = ['min' => '1.7.8.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.8.0', 'max' => '8.99.99'];
 
         parent::__construct();
 

--- a/demomultistoreform/demomultistoreform.php
+++ b/demomultistoreform/demomultistoreform.php
@@ -46,7 +46,7 @@ class DemoMultistoreForm extends Module
 
         $this->displayName = 'Demo multistore configuration form';
         $this->description = 'Module created for the purpose of showing an example of multistore configuration form';
-        $this->ps_versions_compliancy = array('min' => '1.7.8.0', 'max' => '1.7.8.0');
+        $this->ps_versions_compliancy = array('min' => '1.7.8.0', 'max' => _PS_VERSION_);
     }
 
     /**

--- a/demomultistoreform/demomultistoreform.php
+++ b/demomultistoreform/demomultistoreform.php
@@ -46,7 +46,7 @@ class DemoMultistoreForm extends Module
 
         $this->displayName = 'Demo multistore configuration form';
         $this->description = 'Module created for the purpose of showing an example of multistore configuration form';
-        $this->ps_versions_compliancy = array('min' => '1.7.8.0', 'max' => _PS_VERSION_);
+        $this->ps_versions_compliancy = array('min' => '1.7.8.0', 'max' => '8.99.99');
     }
 
     /**

--- a/demosymfonyform/demosymfonyform.php
+++ b/demosymfonyform/demosymfonyform.php
@@ -41,7 +41,7 @@ class DemoSymfonyForm extends Module
             'Modules.DemoSymfonyForm.Admin'
         );
 
-        $this->ps_versions_compliancy = ['min' => '1.7.8.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.8.0', 'max' => '8.99.99'];
     }
 
     public function getTabs()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The demo multistore module wouldn't install itself due to max  ps compatibility being 1.7.8.0, this PR sets the max version to current version (just like other example modules)
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Copy the `demomultistoreform` module in your `modules` folder and try installing it, before this PR you will have an error, with this PR it works
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
