### PR TITLE
DemoSymfonyForm is not compatible with PS 8.0.x

### DIFF
--- a/demosymfonyform/README.md
+++ b/demosymfonyform/README.md
@@ -9,7 +9,7 @@ are being used. You can use these pages as examples of how to integrate these in
 
 ### Supported PrestaShop versions
 
-This module is compatible with and 1.7.8.0 and above versions.
+This module is compatible with 1.7.8.x only.
  
 ### Requirements
  

--- a/demosymfonyform/demosymfonyform.php
+++ b/demosymfonyform/demosymfonyform.php
@@ -41,7 +41,7 @@ class DemoSymfonyForm extends Module
             'Modules.DemoSymfonyForm.Admin'
         );
 
-        $this->ps_versions_compliancy = ['min' => '1.7.8.0', 'max' => '8.99.99'];
+        $this->ps_versions_compliancy = ['min' => '1.7.8.0', 'max' => '1.7.9.99'];
     }
 
     public function getTabs()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | [TextWithUnitType::class](https://github.com/PrestaShop/example-modules/blob/master/demosymfonyform/src/Form/DemoConfigurationTextType.php#L55) is not found in PS 8.0.x <br> ['PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig'](https://github.com/PrestaShop/example-modules/blob/master/demosymfonyform/views/templates/admin/form.html.twig#L30) is not valid in PS 8.0.x either.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes {paste the issue here}.
| How to test?      | [Due to core updates in 8.0](https://devdocs.prestashop.com/8/modules/core-updates/8.0/)
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
