### PR TITLE
Add compatibility with Prestashop 8.0.0 on democontrollertabs module

### DIFF
--- a/democontrollertabs/README.md
+++ b/democontrollertabs/README.md
@@ -3,6 +3,8 @@ Demo Controller Tabs
 
 This module demonstrates how to create modern Controllers and associate Tabs, it was designed for test purposes and as an example.
 
+Tested with PS 8.0.0 and below.
+
 Please note this module is an example only, not a mandatory structure.
 
  1. Symfony Controller with permission

--- a/democontrollertabs/views/templates/admin/layout.html.twig
+++ b/democontrollertabs/views/templates/admin/layout.html.twig
@@ -8,8 +8,9 @@
  * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
  *#}
 
-{% extends '@PrestaShop/Admin/layout.html.twig' %}
-
+{% extends '@!PrestaShop/Admin/layout.html.twig' %}
+{# Since PS 8.0.0 you can use @PrestaShopCore instead of @!Prestashop
+(https://devdocs.prestashop-project.org/8/modules/concepts/templating/admin-views/#override-templates) #}
 {% block content %}
     <div class="row justify-content-center">
         <div class="col">
@@ -18,8 +19,8 @@
                     <h3 class="card-header">
                         <i class="material-icons">settings</i> {% block controllerTitle %}{{ 'Configure controller'|trans({}, 'Modules.Controllertab.Admin') }}{% endblock %}
                     </h3>
-                    <div class="card-block row">
-                        <div class="card-text">
+                    <div class="card-body card-block">
+                        <div class="form-wrapper card-text">
                             <div class="row">
                                 <div class="col-sm">
                                     <div class="alert alert-info" role="alert">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add compatibility with Prestashop 8.0.0 on democontrollertabs module (just fix the display of templates)
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #108 
| How to test?      | See if democontrollertabs pages are well displayed
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
