### PR TITLE
Use right classes on form for demosymfonyform

### DIFF
--- a/demosymfonyform/views/templates/admin/form.html.twig
+++ b/demosymfonyform/views/templates/admin/form.html.twig
@@ -35,8 +35,8 @@
     <h3 class="card-header">
       <i class="material-icons">settings</i> {{ 'Text form types'|trans({}, 'Modules.DemoSymfonyForm.Admin') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(demoConfigurationTextForm) }}
       </div>
     </div>

--- a/demosymfonyform/views/templates/admin/multipleForms.html.twig
+++ b/demosymfonyform/views/templates/admin/multipleForms.html.twig
@@ -35,8 +35,8 @@
     <h3 class="card-header">
       <i class="material-icons">settings</i> {{ 'Choice form types'|trans({}, 'Modules.DemoSymfonyForm.Admin') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
           {{ form_widget(demoConfigurationChoiceForm) }}
       </div>
     </div>
@@ -55,8 +55,8 @@
     <h3 class="card-header">
       <i class="material-icons">settings</i> {{ 'Other form types'|trans({}, 'Modules.DemoSymfonyForm.Admin') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(demoConfigurationOtherForm) }}
       </div>
     </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The form was not well displayed with prestashop 8 because of uses wrong html classes on it
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #108 
| How to test?      | Install module demosymfonyform > Configure the module > Check form display
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
