### PR TITLE
Add compatibility with Prestashop 8.0.0 on demovieworderhooks module

### DIFF
--- a/demovieworderhooks/README.md
+++ b/demovieworderhooks/README.md
@@ -1,7 +1,7 @@
 Demo View Order Hooks
 =====================
 
-This module was created in order to demonstrate how to use the new hooks introduced with the new "View an Order" back-office page in PrestaShop 1.7.7.0 .
+This module was created in order to demonstrate how to use the new hooks introduced with the new "View an Order" back-office page in PrestaShop 8.0.0 and below.
 
 It uses the following hooks:
 - displayAdminOrderTabContent

--- a/demovieworderhooks/config/services.yml
+++ b/demovieworderhooks/config/services.yml
@@ -10,45 +10,54 @@ services:
 
   prestashop.module.demovieworderhooks.repository.order_repository:
     class: PrestaShop\Module\DemoViewOrderHooks\Repository\OrderRepository
+    public: true
 
   prestashop.module.demovieworderhooks.repository.order_signature_repository:
     class: PrestaShop\Module\DemoViewOrderHooks\Repository\OrderSignatureRepository
+    public: true
     factory: ['@doctrine.orm.default_entity_manager', getRepository]
     arguments:
       - PrestaShop\Module\DemoViewOrderHooks\Entity\OrderSignature
 
   prestashop.module.demovieworderhooks.repository.order_review_repository:
     class: PrestaShop\Module\DemoViewOrderHooks\Repository\OrderReviewRepository
+    public: true
     factory: ['@doctrine.orm.default_entity_manager', getRepository]
     arguments:
       - PrestaShop\Module\DemoViewOrderHooks\Entity\OrderReview
 
   prestashop.module.demovieworderhooks.repository.package_location_repository:
     class: PrestaShop\Module\DemoViewOrderHooks\Repository\PackageLocationRepository
+    public: true
     factory: ['@doctrine.orm.default_entity_manager', getRepository]
     arguments:
       - PrestaShop\Module\DemoViewOrderHooks\Entity\PackageLocation
 
   prestashop.module.demovieworderhooks.presenter.orders_presenter:
     class: PrestaShop\Module\DemoViewOrderHooks\Presenter\OrdersPresenter
+    public: true
     arguments:
       - '@router.default'
       - '@prestashop.core.localization.locale.context_locale'
 
   prestashop.module.demovieworderhooks.presenter.order_signature_presenter:
     class: PrestaShop\Module\DemoViewOrderHooks\Presenter\OrderSignaturePresenter
+    public: true
     arguments:
       - '@=service("prestashop.module.demovieworderhooks").getPathUri() ~ parameter("signatureImgDirectory")'
 
   prestashop.module.demovieworderhooks.presenter.order_review_presenter:
     class: PrestaShop\Module\DemoViewOrderHooks\Presenter\OrderReviewPresenter
+    public: true
 
   prestashop.module.demovieworderhooks.presenter.package_locations_presenter:
     class: PrestaShop\Module\DemoViewOrderHooks\Presenter\PackageLocationsPresenter
+    public: true
     calls:
       - { method: setTranslator, arguments: ['@translator'] }
 
   prestashop.module.demovieworderhooks.presenter.order_link_presenter:
     class: PrestaShop\Module\DemoViewOrderHooks\Presenter\OrderLinkPresenter
+    public: true
     arguments:
       - '@router.default'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix services definition to enable PS 8.0.0 compatibility
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #108 
| How to test?      | Install module demovieworderhooks > Go to order list / order detail page and check that all hooks works
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
