### PR TITLE
MailTheme example module for PS8

### DIFF
--- a/example_module_mailtheme/example_module_mailtheme.php
+++ b/example_module_mailtheme/example_module_mailtheme.php
@@ -227,7 +227,7 @@ class example_module_mailtheme extends Module
      */
     private function addDarkTheme(ThemeCollectionInterface $themes)
     {
-        $scanner = new FolderThemeScanner();
+        $scanner = new FolderThemeScanner(_PS_MODULE_DIR_);
         $darkTheme = $scanner->scan(__DIR__ . '/mails/themes/dark_modern');
         if (null !== $darkTheme && $darkTheme->getLayouts()->count() > 0) {
             $themes->add($darkTheme);

--- a/example_module_mailtheme/example_module_mailtheme.php
+++ b/example_module_mailtheme/example_module_mailtheme.php
@@ -182,7 +182,7 @@ class example_module_mailtheme extends Module
 
             $theme->getLayouts()->add(new Layout(
                 'customized_template',
-                __DIR__ . '/mails/layouts/customized_' . $theme->getName() . '_layout.html.twig',
+                '@Modules/example_module_mailtheme/mails/layouts/customized_' . $theme->getName() . '_layout.html.twig',
                 '',
                 $this->name
             ));
@@ -211,7 +211,7 @@ class example_module_mailtheme extends Module
             $orderIndex = $theme->getLayouts()->indexOf($orderConfLayout);
             $theme->getLayouts()->offsetSet($orderIndex, new Layout(
                 $orderConfLayout->getName(),
-                __DIR__ . '/mails/layouts/extended_' . $theme->getName() . '_order_conf_layout.html.twig',
+                 '@Modules/example_module_mailtheme/mails/layouts/extended_' . $theme->getName() . '_order_conf_layout.html.twig',
                 ''
             ));
         }

--- a/example_module_mailtheme/views/templates/admin/index.html.twig
+++ b/example_module_mailtheme/views/templates/admin/index.html.twig
@@ -1,4 +1,7 @@
-{% extends '@PrestaShop/Admin/layout.html.twig' %}
+{% extends '@!PrestaShop/Admin/layout.html.twig' %}
+{# Since PS 8.0.0 you can use @PrestaShopCore instead of @!Prestashop
+(https://devdocs.prestashop-project.org/8/modules/concepts/templating/admin-views/#override-templates) #}
+{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 {% trans_default_domain "Admin.Design.Feature" %}
 
 {% block content %}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Upgrade the MailTheme example module for PS8. Needs https://github.com/PrestaShop/PrestaShop/pull/30295.
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/example-modules/issues/108.
| How to test?      | Try the module and make sure it's working as intended.
| Possible impacts? | mailtheme module only.