### PR TITLE
Use TranslateType with FormattedTextareaType

### DIFF
--- a/demosymfonyform/src/Form/DemoConfigurationTextType.php
+++ b/demosymfonyform/src/Form/DemoConfigurationTextType.php
@@ -87,10 +87,12 @@ class DemoConfigurationTextType extends TranslatorAwareType
                 ],
             ]
             )
-            ->add('translatable_formatted_text_area_type', TranslatableType::class, [
+            ->add('translatable_formatted_text_area_type', TranslateType::class, [
                 'label' => $this->trans('Translatable formatted text area type', 'Modules.DemoSymfonyForm.Admin'),
                 'help' => $this->trans('Throws error if length is > 30', 'Modules.DemoSymfonyForm.Admin'),
                 'type' => FormattedTextareaType::class,
+                'locales' => $this->locales,
+                'hideTabs' => false,
                 'required' => false,
                 'options' => [
                     'constraints' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If you wish to use FormattedTextareaType as type, your base type must be TranslateType instead of TranslatableType. Do not forget to add the option hideTabs at true if you want to display the languages list above the WYSIWYG (source : https://devdocs.prestashop-project.org/8/development/components/form/types-reference/translatable/).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/example-modules/issues/126.
| How to test?      | -
| Possible impacts? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
