### PR TITLE
Set parent::__construct after add definition

### DIFF
--- a/demooverrideobjectmodel/override/classes/Manufacturer.php
+++ b/demooverrideobjectmodel/override/classes/Manufacturer.php
@@ -20,7 +20,7 @@ class Manufacturer extends ManufacturerCore
         $id = null,
         $idLang = null
     ) {
-        parent::__construct($id, $idLang);
         self::$definition['fields']['code'] = ['type' => self::TYPE_STRING, 'size' => 64];
+        parent::__construct($id, $idLang);
     }
 }


### PR DESCRIPTION
If the parent::__construct is before de self::$definition['fields']['code'] = ['type' => self::TYPE_STRING, 'size' => 64]; The objectModel can't be updated.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the parent::__contruct before the self::definition because the objectModel can't be updated
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Follow the exemple
| Possible impacts? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
