### PR TITLE
fetchOne --> fetch

### DIFF
--- a/demoextendsymfonyform1/src/Repository/ReviewerRepository.php
+++ b/demoextendsymfonyform1/src/Repository/ReviewerRepository.php
@@ -54,7 +54,7 @@ class ReviewerRepository
 
         $queryBuilder->setParameter('customer_id', $customerId);
 
-        return (int) $queryBuilder->execute()->fetchOne(PDO::FETCH_COLUMN);
+        return (int) $queryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
     }
 
     /**
@@ -76,6 +76,6 @@ class ReviewerRepository
 
         $queryBuilder->setParameter('customer_id', $customerId);
 
-        return (bool) $queryBuilder->execute()->fetchOne(PDO::FETCH_COLUMN);
+        return (bool) $queryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
     }
 }


### PR DESCRIPTION
The docs clearly state that the module's minimum PS version is v1.7.6.

But fetchOne has only been introduced in Doctrine in the PS8 version.

So for compatibility with PS1.7.6  and higher we still need fetch.