### PR TITLE
Fix for possible SQL syntax error during installation of the demodoctrine module

### DIFF
--- a/demodoctrine/src/Database/QuoteInstaller.php
+++ b/demodoctrine/src/Database/QuoteInstaller.php
@@ -53,7 +53,7 @@ class QuoteInstaller
         $errors = [];
         $this->dropTables();
         $sqlInstallFile = __DIR__ . '/../../Resources/data/install.sql';
-        $sqlQueries = explode(PHP_EOL, file_get_contents($sqlInstallFile));
+        $sqlQueries = preg_split('/\r\n|\r|\n/', file_get_contents($sqlInstallFile));
         $sqlQueries = str_replace('PREFIX_', $this->dbPrefix, $sqlQueries);
 
         foreach ($sqlQueries as $query) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | During the installation of the module on Windows machine, I encountered an SQL syntax error, which was caused by the incorrect splitting of queries from the `install.sql` file. The lines were not split at all.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | Try installing on a Windows PC before and after the patch.
