### PR TITLE
Remove duplicate license definitions in composer.json files

### DIFF
--- a/demoextendgrid/composer.json
+++ b/demoextendgrid/composer.json
@@ -10,7 +10,6 @@
       "name": "PrestaShop Core team"
     }
   ],
-  "license": "AFL-3.0",
   "autoload": {
     "psr-4": {
       "PrestaShop\\Module\\DemoExtendGrid\\": "src/"

--- a/demoextendsymfonyform1/composer.json
+++ b/demoextendsymfonyform1/composer.json
@@ -15,7 +15,6 @@
       "PrestaShop\\Module\\DemoHowToExtendSymfonyForm\\": "src/"
     }
   },
-  "license": "MIT",
   "type": "prestashop-module",
   "config": {
     "prepend-autoloader": false

--- a/demoextendsymfonyform3/composer.json
+++ b/demoextendsymfonyform3/composer.json
@@ -7,6 +7,5 @@
       "DemoCQRSHooksUsage\\": "src/"
     }
   },
-  "license": "MIT",
   "type": "prestashop-module"
 }

--- a/demoextendsymfonyform4/composer.json
+++ b/demoextendsymfonyform4/composer.json
@@ -7,6 +7,5 @@
       "DemoCQRSHooksUsage\\": "src/"
     }
   },
-  "license": "MIT",
   "type": "prestashop-module"
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Some of the composer.json files had duplicate license definitions. Some even had conflicting information. Removed duplicates and defaulted to AFL-3.0 as that is set for the whole repo.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | - cannot create issues in this repo. If we really want to spam the Prestashop repo with this I can create an issue there
| Sponsor company   | 
| How to test?      | `find . -name composer.json|xargs grep 'license'|cut -d' ' -f 1|sort|uniq -d` should not return any files
