### PR TITLE
Adapt module demoextendsymfonyform4 for v9

### DIFF
--- a/demoextendsymfonyform4/composer.json
+++ b/demoextendsymfonyform4/composer.json
@@ -7,5 +7,8 @@
       "DemoCQRSHooksUsage\\": "src/"
     }
   },
+  "require": {
+      "php": ">=8.1"
+  },
   "type": "prestashop-module"
 }

--- a/demoextendsymfonyform4/config/services.yml
+++ b/demoextendsymfonyform4/config/services.yml
@@ -1,7 +1,7 @@
 services:
   _defaults:
     public: true
-#  @see  https://devdocs.prestashop.com/1.7/development/architecture/migration-guide/forms/cqrs-usage-in-forms/ for CQRS pattern usage examples.
+#  @see  https://devdocs.prestashop-project.org/9/development/architecture/migration-guide/forms/cqrs-usage-in-forms/ for CQRS pattern usage examples.
   democqrshooksusage.domain.reviewer.command_handler.toggle_is_allowed_to_review_handler:
     class: 'DemoCQRSHooksUsage\Domain\Reviewer\CommandHandler\ToggleIsAllowedToReviewHandler'
     autoconfigure: true
@@ -25,3 +25,7 @@ services:
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
+
+  DemoCQRSHooksUsage\Controller\Admin\CustomerReviewController:
+    autowire: true
+    autoconfigure: true

--- a/demoextendsymfonyform4/demoextendsymfonyform4.php
+++ b/demoextendsymfonyform4/demoextendsymfonyform4.php
@@ -24,7 +24,6 @@ use PrestaShop\PrestaShop\Core\Search\Filters\CustomerFilters;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class DemoExtendSymfonyForm1 demonstrates the usage of CQRS pattern and hooks.
@@ -72,7 +71,7 @@ class DemoExtendSymfonyForm4 extends Module
     /**
      * Install module and register hooks to allow grid modification.
      *
-     * @see https://devdocs.prestashop.com/1.7/modules/concepts/hooks/use-hooks-on-modern-pages/
+     * @see https://devdocs.prestashop-project.org/9/modules/concepts/hooks/use-hooks-on-modern-pages/
      *
      * @return bool
      */
@@ -198,7 +197,7 @@ class DemoExtendSymfonyForm4 extends Module
         /**
          * This part demonstrates the usage of CQRS pattern query to perform read operation from Reviewer entity.
          *
-         * @see https://devdocs.prestashop.com/1.7/development/architecture/cqrs/ for more detailed information.
+         * @see https://devdocs.prestashop-project.org/9/development/architecture/domain/cqrs/ for more detailed information.
          *
          * As this is our recommended approach of reading the data but we not force to use this pattern in modules -
          * you can use directly an entity here or wrap it in custom service class.
@@ -254,7 +253,7 @@ class DemoExtendSymfonyForm4 extends Module
         try {
             /*
              * This part demonstrates the usage of CQRS pattern command to perform write operation for Reviewer entity.
-             * @see https://devdocs.prestashop.com/1.7/development/architecture/domain/cqrs/ for more detailed information.
+             * @see https://devdocs.prestashop-project.org/9/development/architecture/domain/cqrs/ for more detailed information.
              *
              * As this is our recommended approach of writing the data but we not force to use this pattern in modules -
              * you can use directly an entity here or wrap it in custom service class.

--- a/demoextendsymfonyform4/src/Controller/Admin/CustomerReviewController.php
+++ b/demoextendsymfonyform4/src/Controller/Admin/CustomerReviewController.php
@@ -15,39 +15,35 @@ use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotCreateReviewerException;
 use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotToggleAllowedToReviewStatusException;
 use DemoCQRSHooksUsage\Domain\Reviewer\Exception\ReviewerException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
-use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
 
 /**
  * This controller holds all custom actions which are added by extending "Sell > Customers" page.
  *
- * @see https://devdocs.prestashop.com/1.7/modules/concepts/controllers/admin-controllers/ for more details.
+ * @see https://devdocs.prestashop-project.org/9/modules/concepts/controllers/admin-controllers/ for more details.
  */
-class CustomerReviewController extends FrameworkBundleAdminController
+class CustomerReviewController extends PrestaShopAdminController
 {
     /**
      * Catches the toggle action of customer review.
-     *
-     * @param int $customerId
-     *
-     * @return RedirectResponse
      */
-    public function toggleIsAllowedForReviewAction($customerId)
+    public function toggleIsAllowedForReviewAction(int $customerId): JsonResponse
     {
         try {
             /*
              * This part demonstrates the usage of CQRS pattern command to perform write operation for Reviewer entity.
-             * @see https://devdocs.prestashop.com/1.7/development/architecture/cqrs/ for more detailed information.
+             * @see https://devdocs.prestashop-project.org/9/development/architecture/domain/cqrs/ for more detailed information.
              *
              * As this is our recommended approach of writing the data but we not force to use this pattern in modules -
              * you can use directly an entity here or wrap it in custom service class.
              */
-            $this->getCommandBus()->handle(new ToggleIsAllowedToReviewCommand((int) $customerId));
+            $this->dispatchCommand(new ToggleIsAllowedToReviewCommand((int) $customerId));
 
             return $this->json(
                 [
                     'status' => true,
-                    'message' => $this->trans('Successful update.', 'Admin.Notifications.Success')
+                    'message' => $this->trans('Successful update.', [], 'Admin.Notifications.Success')
                 ]
             );
         } catch (ReviewerException $e) {
@@ -66,23 +62,24 @@ class CustomerReviewController extends FrameworkBundleAdminController
      * Gets error message mappings which are later used to display friendly user error message instead of the
      * exception message.
      *
-     * @see https://devdocs.prestashop.com/1.7/development/architecture/domain-exceptions/ for more detailed explanation
-     *
-     * @return array
+     * @see https://devdocs.prestashop-project.org/9/development/architecture/domain/domain-exceptions/ for more detailed explanation
      */
     private function getErrorMessageMapping()
     {
         return [
             CustomerException::class => $this->trans(
                 'Something bad happened when trying to get customer id',
+                [],
                 'Modules.Democqrshooksusage.Customerreviewcontroller'
             ),
             CannotCreateReviewerException::class => $this->trans(
                 'Failed to create reviewer',
+                [],
                 'Modules.Democqrshooksusage.Customerreviewcontroller'
             ),
             CannotToggleAllowedToReviewStatusException::class => $this->trans(
                 'An error occurred while updating the status.',
+                [],
                 'Modules.Democqrshooksusage.Customerreviewcontroller'
             ),
         ];

--- a/demoextendsymfonyform4/src/Domain/Reviewer/Command/UpdateIsAllowedToReviewCommand.php
+++ b/demoextendsymfonyform4/src/Domain/Reviewer/Command/UpdateIsAllowedToReviewCommand.php
@@ -21,15 +21,14 @@ class UpdateIsAllowedToReviewCommand
 {
     private CustomerId $customerId;
 
-    private bool $isAllowedToReview;
-
     /**
      * @throws CustomerException
      */
-    public function __construct(int $customerId, bool $isAllowedToReview)
-    {
+    public function __construct(
+        int $customerId,
+        private bool $isAllowedToReview
+    ) {
         $this->customerId = new CustomerId($customerId);
-        $this->isAllowedToReview = $isAllowedToReview;
     }
 
     public function getCustomerId(): CustomerId

--- a/demoextendsymfonyform4/src/Domain/Reviewer/CommandHandler/AbstractReviewerHandler.php
+++ b/demoextendsymfonyform4/src/Domain/Reviewer/CommandHandler/AbstractReviewerHandler.php
@@ -21,11 +21,9 @@ class AbstractReviewerHandler
     /**
      * Creates a reviewer.
      *
-     * @param $customerId
-     *
      * @throws CannotCreateReviewerException
      */
-    protected function createReviewer($customerId): Reviewer
+    protected function createReviewer(int $customerId): Reviewer
     {
         try {
             $reviewer = new Reviewer();
@@ -42,7 +40,7 @@ class AbstractReviewerHandler
             }
         } catch (PrestaShopException $exception) {
             /*
-             * @see https://devdocs.prestashop.com/1.7/development/architecture/domain-exceptions/
+             * @see https://devdocs.prestashop-project.org/9/development/architecture/domain/domain-exceptions/
              */
             throw new CannotCreateReviewerException(
                 sprintf(

--- a/demoextendsymfonyform4/src/Domain/Reviewer/CommandHandler/ToggleIsAllowedToReviewHandler.php
+++ b/demoextendsymfonyform4/src/Domain/Reviewer/CommandHandler/ToggleIsAllowedToReviewHandler.php
@@ -29,8 +29,6 @@ class ToggleIsAllowedToReviewHandler extends AbstractReviewerHandler
     }
 
     /**
-     * @param ToggleIsAllowedToReviewCommand $command
-     *
      * @throws CannotCreateReviewerException
      * @throws CannotToggleAllowedToReviewStatusException
      */
@@ -54,7 +52,7 @@ class ToggleIsAllowedToReviewHandler extends AbstractReviewerHandler
             }
         } catch (PrestaShopException $exception) {
             /*
-             * @see https://devdocs.prestashop.com/1.7/development/architecture/domain-exceptions/
+             * @see https://devdocs.prestashop-project.org/9/development/architecture/domain/domain-exceptions/
              */
             throw new CannotToggleAllowedToReviewStatusException(
                 'An unexpected error occurred when updating reviewer status'

--- a/demoextendsymfonyform4/src/Domain/Reviewer/CommandHandler/UpdateIsAllowedToReviewHandler.php
+++ b/demoextendsymfonyform4/src/Domain/Reviewer/CommandHandler/UpdateIsAllowedToReviewHandler.php
@@ -47,7 +47,7 @@ class UpdateIsAllowedToReviewHandler extends AbstractReviewerHandler
             }
         } catch (PrestaShopException $exception) {
             /*
-             * @see https://devdocs.prestashop.com/1.7/development/architecture/domain-exceptions/
+             * @see https://devdocs.prestashop-project.org/9/development/architecture/domain/domain-exceptions/
              */
             throw new CannotToggleAllowedToReviewStatusException(
                 'An unexpected error occurred when updating reviewer status'

--- a/demoextendsymfonyform4/src/Repository/ReviewerRepository.php
+++ b/demoextendsymfonyform4/src/Repository/ReviewerRepository.php
@@ -15,14 +15,10 @@ use PDO;
 
 class ReviewerRepository
 {
-    private Connection $connection;
-
-    private string $dbPrefix;
-
-    public function __construct(Connection $connection, string $dbPrefix)
-    {
-        $this->connection = $connection;
-        $this->dbPrefix = $dbPrefix;
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly string $dbPrefix
+    ) {
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adapt module demoextendsymfonyform4 for v9.<br>**(btw, it looks like it's the same module as demoextendsymfonyform3. Maybe we should delete this module 🤷‍♂️)**
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38284
| Sponsor company   | PrestaShop SA
| How to test?      | ~
