### PR TITLE
Set version max for ps compliancy for demomoduleroutes

### DIFF
--- a/demomoduleroutes/demomoduleroutes.php
+++ b/demomoduleroutes/demomoduleroutes.php
@@ -27,7 +27,7 @@ class DemoModuleRoutes extends Module
         $this->name = 'demomoduleroutes';
         $this->author = 'PrestaShop';
         $this->version = '1.0.0';
-        $this->ps_versions_compliancy = ['min' => '8.0.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '8.0.0', 'max' => '9.99.99'];
 
         parent::__construct();
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Set version max for ps compliancy for demomoduleroutes.<br>**Nothing else to do for compatibility with v9!**
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38288
| Sponsor company   | PrestaShop SA
| How to test?      | ~
