### PR TITLE
Fixed SupplierExtraImageUploader.php using incorrect namespace for ImageOptimizationException class

### DIFF
--- a/demoextendsymfonyform2/src/Uploader/SupplierExtraImageUploader.php
+++ b/demoextendsymfonyform2/src/Uploader/SupplierExtraImageUploader.php
@@ -14,7 +14,7 @@ namespace PrestaShop\Module\DemoExtendSymfonyForm\Uploader;
 
 use PrestaShop\Module\DemoExtendSymfonyForm\Entity\SupplierExtraImage;
 use PrestaShop\Module\DemoExtendSymfonyForm\Repository\SupplierExtraImageRepository;
-use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageOptimizationException;
+use Prestashop\Prestashop\Core\Image\Exception\ImageOptimizationException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageUploadException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\MemoryLimitException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The namespace of class ImageOptimizationException has changed since version 1.7.8
| Type?             | bug fix
| BC breaks?        | class namespace
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   |
| How to test?      | Clone this sample module into the `/modules` folder of a Prestashop version 1.7.8 or higher, your IDE will indicate  `Undefined type 'PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageOptimizationException'`

## What this change is about
The namespace of class `ImageOptimizationException` has changed since version 1.7.8
This class is used to throw an exception when resizing, cutting or optimizing image fails in the `uploadFromTemp` function.

- version 1.7.7 and earlier
`use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageOptimizationException;`
- since version 1.7.8
`use Prestashop\Prestashop\Core\Image\Exception\ImageOptimizationException;`

```diff
+ use Prestashop\Prestashop\Core\Image\Exception\ImageOptimizationException;
- use Prestashop\Prestashop\Core\Image\Uploader\Exception\ImageOptimizationException;
```
```php
use Prestashop\Prestashop\Core\Image\Exception\ImageOptimizationException;

class SupplierExtraImageUploader implements ImageUploaderInterface
{
    /**
     * Uploads resized image from temporary folder to image destination
     *
     * @throws ImageOptimizationException
     * @throws MemoryLimitException
     */
    protected function uploadFromTemp(string $temporaryImageName, string $destination): void
    {
        if (!\ImageManager::checkImageMemoryLimit($temporaryImageName)) {
            throw new MemoryLimitException('Cannot upload image due to memory restrictions');
        }

        if (!\ImageManager::resize($temporaryImageName, $destination)) {
            throw new ImageOptimizationException('An error occurred while uploading the image. Check your directory permissions.');
        }

        unlink($temporaryImageName);
    }
```
